### PR TITLE
dogfood: rewrite release-check skill + workflow for CI-gated flow

### DIFF
--- a/.spores/ONRAMP.md
+++ b/.spores/ONRAMP.md
@@ -31,7 +31,7 @@ Returns the highest-ULID `ready` task from `.spores/tasks/`. **Important:** the 
 
 ### `skill run release-check`
 
-The pre-release checklist. Currently written for a manual publish flow — **known stale**, pending first successful CI publish. See "Known drift" below.
+The CI-gated release checklist. Your job is to land a `chore: release vX.Y.Z` PR on `main`, tag the merge commit `vX.Y.Z`, push the tag, and watch `publish.yml` ship via OIDC trusted publishing. No local `npm publish`.
 
 ## Source of truth — what lives where
 
@@ -42,17 +42,13 @@ The pre-release checklist. Currently written for a manual publish flow — **kno
 | Current task you're working | `.spores/tasks/*.json` (manually mirrored from GH) | Exercised by `spores task next` as part of the dogfood |
 | Durable non-obvious facts | `.spores/memory/*.json` | "Why" that isn't in the code |
 | Values and in-turn orientation | `.spores/personas/spores-maintainer.md` | What you prioritize while wearing the hat |
-| Release procedure | `.spores/skills/release-check/skill.md` + `.spores/workflows/spores-release.json` | Both currently stale — see below |
+| Release procedure | `.spores/skills/release-check/skill.md` + `.spores/workflows/spores-release.json` | CI-gated via `.github/workflows/publish.yml` (OIDC) |
 
 When two sources disagree, trust git and GitHub. Update the dogfood to match — that's the "dogfood as operational workspace, not curated fixture" stance.
 
 ## Known drift (refresh as you use it)
 
 This section is a living punch list. If you fix something, delete the bullet.
-
-- **`skills/release-check/skill.md`** is a manual-publish checklist. The real flow is now CI-driven: merge to main → tag `v*.*.*` → publish.yml runs. Update this skill to a ~4-step CI-gate checklist *after* the first successful CI publish lands (v0.1.1, expected soon). Don't theorize — update from lived experience.
-
-- **`workflows/spores-release.json`** is a 9-node manual-publish DAG. Same story: update after first CI publish. Likely shrinks to 3-4 nodes or gets replaced with a "verify-ci-green" gate.
 
 - **`tasks/` sync with GitHub issues is manual.** When you add a ready issue, seed a matching task file. When you close a GH issue, mark the task done. This is a bandaid — the real fix is a TaskAdapter that reads from GitHub issues directly (filed as a v0.2+ issue). Until then, keep them in hand-sync.
 

--- a/.spores/skills/release-check/skill.md
+++ b/.spores/skills/release-check/skill.md
@@ -1,93 +1,74 @@
 ---
 name: release-check
-description: Activate when cutting a new @tnezdev/spores release — verifies the green-gate checklist before tagging and publishing
-tags: [spores, release, npm]
+description: Activate when cutting a new @tnezdev/spores release — the CI-gated checklist for landing a version bump and triggering the tag publish
+tags: [spores, release, npm, ci]
 ---
 
 # Release check — @tnezdev/spores
 
-Before cutting a new version, every one of these must be green. If any step fails, **do not tag**. Fix the failure, commit, and restart the checklist.
+Releases are **CI-gated**. You don't run `npm publish`; you push a `vX.Y.Z` tag and `.github/workflows/publish.yml` does the rest via npm Trusted Publishing (OIDC). Your job is to land a clean version bump on `main` and hand the tag to CI.
 
-## 1. Clean working tree
+**The gate is CI. Do not publish locally.** There is no `NPM_TOKEN`; there is no path for a local `npm publish` to succeed. If you find yourself typing it, stop.
 
-```bash
-git status
-```
+## 1. Land the version bump on main
 
-Must show no uncommitted changes. If there are any, either commit them or stash them — do not publish with a dirty tree.
+Open a `chore: release vX.Y.Z` PR that:
 
-## 2. On main, up to date with remote
+- Bumps `version` in `package.json` per semver.
+- Appends a CHANGELOG entry (or release notes section) covering user-visible changes since the last tag.
+- Keeps `"dependencies": {}` in `package.json`. A non-empty production dependency is a design regression — investigate before shipping.
+
+Merge only after CI (`.github/workflows/ci.yml`) is green on the PR. CI runs `bun test` and `bun run typecheck` — those are the authoritative gates, not a local run.
+
+## 2. Sync and sanity-check main
 
 ```bash
 git checkout main && git pull
+git log -1 --oneline   # confirm the release commit is HEAD
 ```
 
-The commit you're about to tag must exist on `origin/main`. No releasing from feature branches.
+The commit you're about to tag must be the merged release commit on `origin/main`. No tagging from feature branches, no tagging ahead of merge.
 
-## 3. Tests green
-
-```bash
-bun test
-```
-
-**Every** test must pass. No skipped suites, no `.only`. If you see warnings about malformed fixtures (e.g. from test teardown), that's fine — just make sure the summary line reads `0 fail`.
-
-## 4. Typecheck clean
-
-```bash
-bun run typecheck
-```
-
-`tsc --noEmit` must exit 0. A type error is a release blocker, even if tests pass.
-
-## 5. Dependencies still zero
-
-```bash
-cat package.json | jq '.dependencies'
-```
-
-Must print `{}`. Any non-empty production dependency is a design regression — investigate before shipping.
-
-## 6. Package contents sanity check
-
-```bash
-npm pack --dry-run
-```
-
-Scan the file list. Should include `src/`, `package.json`, `README.md`, `AGENTS.md`. Should **not** include `.spores/runs/`, `node_modules/`, test files, or dotfiles that weren't intended.
-
-## 7. Version bump + CHANGELOG
-
-Edit `package.json` and bump `version` per semver. Append a CHANGELOG entry with the user-visible changes since the last tag. Commit as `chore: release vX.Y.Z`.
-
-## 8. Tag and push
+## 3. Tag and push
 
 ```bash
 git tag -a vX.Y.Z -m "vX.Y.Z"
-git push origin main --tags
+git push origin vX.Y.Z
 ```
 
-## 9. Publish
+The tag push is the trigger. `publish.yml` runs on `push: tags: [v*.*.*]` and takes over from here.
+
+## 4. Watch publish.yml run green
 
 ```bash
-npm publish --access public
+gh run watch --exit-status
+# or
+gh run list --workflow=publish.yml --limit 3
 ```
 
-**Pause here for Travis to run this step manually** — npm publish is not autonomous work. Provide him the exact command to run and the version string.
+What the workflow does (for context when reading logs):
 
-## 10. Verify
+1. Checkout + Bun + `bun install --frozen-lockfile`
+2. `bun run typecheck` and `bun test` (re-gate, cheap)
+3. Bootstraps npm 11 via direct tarball download (the runner's bundled npm has historically been corrupt on fresh `ubuntu-latest` images — don't "simplify" this step)
+4. `npm publish --provenance --access public` using OIDC — no token, no secret
+
+If the workflow fails:
+
+- **Do not delete the tag as a first move.** Investigate in the logs; most failures (flaky install, transient registry) are retryable via `gh run rerun`.
+- If the failure is real (bad code landed, version bump wrong), fix forward on `main` with a new patch version — `vX.Y.(Z+1)` — and a new tag. A published version is immutable; don't chase the old number.
+- Only delete-and-retag if the tag was pushed to the wrong commit *and nothing published*. Confirm with `npm view @tnezdev/spores versions` before retagging.
+
+## 5. Verify the registry
 
 ```bash
 npm view @tnezdev/spores version
 ```
 
-Should print the just-published version. If it doesn't, wait 30 seconds and retry — npm registry propagation.
+Should print the version you just tagged. If it lags, wait 30 seconds and retry — npm registry propagation.
 
-## On failure
+Also spot-check provenance on https://www.npmjs.com/package/@tnezdev/spores — the published version should show a "Built and signed on GitHub Actions" badge linking back to the workflow run. That badge is the whole point of OIDC; its absence means provenance attestation didn't attach and is worth investigating.
 
-If any step fails:
+## On failure — general rule
 
-- **Do not tag.** A tag is durable; an unpublished bug isn't.
-- Fix the underlying issue on a branch.
-- Open a PR, review, merge, then restart this checklist from step 1.
-- Never publish a version with known failing tests or broken types.
+A failed publish run does not mean "roll back." It means "the tag did not ship a package." The main branch is still the source of truth. Fix forward, bump patch, retag. Never rewrite history on `main` to "unship" a tag that CI caught.

--- a/.spores/tasks/01KNS2YM3VDZT4QB1QEZRMXBWQ.json
+++ b/.spores/tasks/01KNS2YM3VDZT4QB1QEZRMXBWQ.json
@@ -1,13 +1,18 @@
 {
   "description": "Update release-check skill + spores-release workflow from manual to CI-gate flow (after first successful CI publish)",
-  "status": "ready",
+  "status": "done",
   "tags": [
     "spores",
     "dogfood",
     "skill"
   ],
   "id": "01KNS2YM3VDZT4QB1QEZRMXBWQ",
-  "annotations": [],
+  "annotations": [
+    {
+      "text": "status: ready → done",
+      "timestamp": "2026-04-09T19:45:51.363Z"
+    }
+  ],
   "created_at": "2026-04-09T12:19:56.667Z",
-  "updated_at": "2026-04-09T12:19:56.667Z"
+  "updated_at": "2026-04-09T19:45:51.363Z"
 }

--- a/.spores/workflows/spores-release.json
+++ b/.spores/workflows/spores-release.json
@@ -1,97 +1,44 @@
 {
   "id": "spores-release",
   "name": "Spores release cut",
-  "description": "End-to-end workflow for cutting a new @tnezdev/spores version",
-  "version": "1.0",
+  "description": "CI-gated release flow for @tnezdev/spores — land version bump on main, push tag, let publish.yml ship via OIDC trusted publishing",
+  "version": "2.0",
   "nodes": [
     {
-      "id": "verify-clean",
-      "label": "Verify clean working tree",
-      "description": "git status shows no uncommitted changes; on main; up to date with origin",
-      "artifact_type": "git-status"
+      "id": "version-bump-pr",
+      "label": "Open release PR",
+      "description": "Bump package.json version per semver, append CHANGELOG entry, open 'chore: release vX.Y.Z' PR — merge only when CI is green",
+      "artifact_type": "pull-request"
     },
     {
-      "id": "run-tests",
-      "label": "Run full test suite",
-      "description": "bun test — all green, no failures, no skipped suites",
-      "artifact_type": "test-report"
-    },
-    {
-      "id": "typecheck",
-      "label": "Run typecheck",
-      "description": "bun run typecheck — tsc --noEmit exits 0",
-      "artifact_type": "typecheck-report"
-    },
-    {
-      "id": "dep-audit",
-      "label": "Verify zero production dependencies",
-      "description": "package.json dependencies field is empty object",
-      "artifact_type": "package-json"
-    },
-    {
-      "id": "pack-dry-run",
-      "label": "Pack dry run",
-      "description": "npm pack --dry-run — scan contents for unwanted files",
-      "artifact_type": "pack-manifest"
-    },
-    {
-      "id": "version-bump",
-      "label": "Bump version and write CHANGELOG",
-      "description": "Edit package.json version per semver; append CHANGELOG entry; commit",
-      "artifact_type": "commit"
+      "id": "sync-main",
+      "label": "Sync main and confirm release commit",
+      "description": "git checkout main && git pull; git log -1 must show the merged release commit",
+      "artifact_type": "git-ref"
     },
     {
       "id": "tag-push",
       "label": "Tag and push",
-      "description": "git tag -a vX.Y.Z -m 'vX.Y.Z' && git push --tags",
+      "description": "git tag -a vX.Y.Z -m 'vX.Y.Z' && git push origin vX.Y.Z — this is the trigger for publish.yml",
       "artifact_type": "git-tag"
     },
     {
-      "id": "publish",
-      "label": "Publish to npm",
-      "description": "npm publish --access public — pause for Travis to run manually",
-      "type": "manual",
-      "artifact_type": "npm-publish"
+      "id": "watch-publish-ci",
+      "label": "Watch publish.yml run",
+      "description": "gh run watch --exit-status — publish.yml runs typecheck+test, bootstraps npm 11 via tarball, publishes with OIDC + provenance. No local publish.",
+      "artifact_type": "ci-run"
     },
     {
-      "id": "verify-published",
-      "label": "Verify registry",
-      "description": "npm view @tnezdev/spores version matches the tag just cut",
+      "id": "verify-registry",
+      "label": "Verify registry + provenance",
+      "description": "npm view @tnezdev/spores version matches tag; npmjs.com page shows 'Built and signed on GitHub Actions' provenance badge",
       "artifact_type": "registry-check"
     }
   ],
   "edges": [
-    {
-      "from": "verify-clean",
-      "to": "run-tests"
-    },
-    {
-      "from": "run-tests",
-      "to": "typecheck"
-    },
-    {
-      "from": "typecheck",
-      "to": "dep-audit"
-    },
-    {
-      "from": "dep-audit",
-      "to": "pack-dry-run"
-    },
-    {
-      "from": "pack-dry-run",
-      "to": "version-bump"
-    },
-    {
-      "from": "version-bump",
-      "to": "tag-push"
-    },
-    {
-      "from": "tag-push",
-      "to": "publish"
-    },
-    {
-      "from": "publish",
-      "to": "verify-published"
-    }
+    { "from": "version-bump-pr", "to": "sync-main" },
+    { "from": "sync-main", "to": "tag-push" },
+    { "from": "tag-push", "to": "watch-publish-ci" },
+    { "from": "watch-publish-ci", "to": "verify-registry" }
   ]
 }


### PR DESCRIPTION
## Summary

- Rewrites `.spores/skills/release-check/skill.md` as a 5-step CI-gated checklist: land `chore: release vX.Y.Z` PR → sync main → tag → watch `publish.yml` → verify registry + provenance. Explicitly rules out local `npm publish`, captures the npm 11 tarball bootstrap gotcha, adds fix-forward guidance for failed publish runs.
- Collapses `.spores/workflows/spores-release.json` from 9 manual nodes to 5 CI-gated nodes; bumps version 1.0 → 2.0.
- Clears the two "known drift" bullets in `.spores/ONRAMP.md` that this commit resolves and updates the source-of-truth table.

Grounded in lived experience: v0.1.1 shipped via `publish.yml` (OIDC trusted publishing) earlier today, closing the loop that #20 opened. No more theorizing about what the CI flow looks like — this is what it *is*.

Resolves the ready task `01KNS2YM3VDZT4QB1QEZRMXBWQ` in `.spores/tasks/`.

## Test plan

- [x] `bun test` — 200 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun src/cli/main.ts workflow show spores-release` — parses and renders v2.0
- [x] `bun src/cli/main.ts skill show release-check` — loads
- [x] `bun src/cli/main.ts task done 01KNS2YM3VDZT4QB1QEZRMXBWQ` — marked done via the dogfood CLI