### PR TITLE
feat(hooks): persona.activated fires, auto-recall memories by persona tags

### DIFF
--- a/.spores/ONRAMP.md
+++ b/.spores/ONRAMP.md
@@ -23,7 +23,7 @@ Read the persona output. Do what step 3 of its "Before picking up work" section 
 
 ### `persona activate spores-maintainer`
 
-Principles, anti-patterns, and a "before picking up work" checklist. Situational tokens (`{{cwd}}`, `{{git_branch}}`, `{{timestamp}}`, `{{hostname}}`) get substituted at activation time. If you're piping into an LLM, this is the context injection. If you're a human, read it and internalize the non-negotiables before you start typing.
+Principles, anti-patterns, and a "before picking up work" checklist. Situational tokens (`{{cwd}}`, `{{git_branch}}`, `{{timestamp}}`, `{{hostname}}`) get substituted at activation time. Below the body, the `persona.activated` hook at `.spores/hooks/persona.activated` auto-recalls memories tagged with the persona's `memory_tags` and appends them — that's where current durable facts (runtime scope, publish path, etc.) come from. If you're piping into an LLM, this whole block is the context injection. If you're a human, read it and internalize the non-negotiables before you start typing.
 
 ### `task next`
 

--- a/.spores/hooks/persona.activated
+++ b/.spores/hooks/persona.activated
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# .spores/hooks/persona.activated
+#
+# Fires after `spores persona activate <name>` has rendered the persona body.
+# Recalls memories tagged with the persona's own memory_tags and appends them
+# to the activation output. This is the cheap v0 realization of the
+# persona memory_tags binding (tnezdev/spores#16, explored via hooks in #26).
+#
+# Contract — env vars set by spores:
+#   SPORES_EVENT               = "persona.activated"
+#   SPORES_BIN                 = path to the spores CLI entry (for callbacks)
+#   SPORES_PERSONA_NAME        = the activated persona's name
+#   SPORES_PERSONA_MEMORY_TAGS = comma-separated list from frontmatter
+#   SPORES_PERSONA_SKILLS      = comma-separated list
+#   SPORES_PERSONA_WORKFLOW    = single string or empty
+#
+# Stdout from this script is appended to the activation output.
+# Non-zero exit is surfaced as a warning — it does not fail the activation.
+
+set -euo pipefail
+
+if [[ -z "${SPORES_PERSONA_MEMORY_TAGS:-}" ]]; then
+  exit 0
+fi
+
+# Split the comma-separated tag list into positional args.
+IFS=',' read -ra tags <<< "$SPORES_PERSONA_MEMORY_TAGS"
+
+echo "## Recalled memory (tags: ${SPORES_PERSONA_MEMORY_TAGS})"
+echo
+
+# Call back into spores for each tag. --tag is repeatable on memory recall,
+# and the CLI handles deduplication by key internally.
+args=()
+for tag in "${tags[@]}"; do
+  [[ -z "$tag" ]] && continue
+  args+=(--tag "$tag")
+done
+
+if [[ ${#args[@]} -eq 0 ]]; then
+  exit 0
+fi
+
+# SPORES_BIN may be a path to main.ts (dev) or the installed `spores` binary.
+# Either way, invoking it via `bun` works in dev and `bun` is a peer dep of
+# this dogfood. For the installed case, prefer `spores` directly on PATH.
+if [[ "$SPORES_BIN" == *.ts ]]; then
+  bun "$SPORES_BIN" memory recall "${args[@]}" || true
+else
+  "$SPORES_BIN" memory recall "${args[@]}" || true
+fi

--- a/.spores/memory/hooks-system-v0-bookmark.json
+++ b/.spores/memory/hooks-system-v0-bookmark.json
@@ -1,0 +1,12 @@
+{
+  "key": "hooks-system-v0-bookmark",
+  "content": "Hook system v0 shipped in #28 with persona.activated only — fires after persona render, dogfood handler recalls memories by persona memory_tags (this is how you're reading this). Design + event catalog + status checklist: tnezdev/spores#26. Next events on deck: task.done (cheapest, wire to memory.remember) and workflow.run.terminated (highest-value, wire to a session-wrap skill). fireHook lives at src/hooks/fire.ts — its clearTimeout trap is documented in the source, don't re-discover it.",
+  "weight": 0.5,
+  "confidence": 1,
+  "tier": "L1",
+  "tags": [
+    "spores",
+    "hooks"
+  ],
+  "timestamp": "2026-04-09T21:59:17.121Z"
+}

--- a/.spores/personas/spores-maintainer.md
+++ b/.spores/personas/spores-maintainer.md
@@ -41,9 +41,8 @@ The time is `{{timestamp}}`.
 - PR description lists implementation picks for anything the spec didn't nail down
 - Assign to yourself and use conventional-commit-style title
 
-## Current state
+## Durable context
 
-Don't encode a snapshot here — it decays. Run the "Before picking up work" commands to get current state from authoritative sources. The only things durable enough to bake in:
+The `persona.activated` hook at `.spores/hooks/persona.activated` recalls memories tagged with this persona's `memory_tags` and appends them below this body at activation time. Read those recalled memories for the current shape of durable non-obvious facts (runtime scope, publish path, v0.1 decisions) — they are the source of truth, not this body.
 
-- All five primitives (memory, workflow, skills, tasks, persona) shipped as of v0.1.
-- `Runtime` is workflow-only. Persona bindings (applying `task_filter`, `memory_tags`, etc.) are the caller's responsibility. Composition object design is tracked in tnezdev/spores#16 and deliberately deferred — don't rush it.
+The job of this body is rules and rhythms that do not change per session: the principles above, the "before picking up work" checklist, the "before opening a PR" list. Situational facts live in memory and get auto-recalled. If a durable fact isn't showing up when you need it, `spores memory remember` it with the right tag and the next activation will surface it automatically.

--- a/.spores/tasks/01KNSYAM3WXBJG4YD92PE6D3BQ.json
+++ b/.spores/tasks/01KNSYAM3WXBJG4YD92PE6D3BQ.json
@@ -1,0 +1,18 @@
+{
+  "description": "hooks: persona.activated fires script hook, wire spores-maintainer to auto-recall memories",
+  "status": "done",
+  "tags": [
+    "spores",
+    "hooks",
+    "v0.2"
+  ],
+  "id": "01KNSYAM3WXBJG4YD92PE6D3BQ",
+  "annotations": [
+    {
+      "text": "status: ready → done",
+      "timestamp": "2026-04-09T20:27:54.920Z"
+    }
+  ],
+  "created_at": "2026-04-09T20:18:21.436Z",
+  "updated_at": "2026-04-09T20:27:54.920Z"
+}

--- a/src/cli/commands/persona.ts
+++ b/src/cli/commands/persona.ts
@@ -1,10 +1,16 @@
+import { fireHook } from "../../hooks/fire.js"
 import { activatePersona } from "../../personas/activate.js"
 import {
   listPersonas,
   loadPersona,
 } from "../../personas/filesystem.js"
 import { resolveSituational } from "../../personas/situational.js"
-import { formatPersona, formatPersonaFile, formatPersonaRefs } from "../format.js"
+import type { PersonaActivationOutput } from "../../types.js"
+import {
+  formatPersonaActivation,
+  formatPersonaFile,
+  formatPersonaRefs,
+} from "../format.js"
 import type { Command } from "../main.js"
 import { output } from "../main.js"
 
@@ -32,5 +38,42 @@ export const personaActivateCommand: Command = async (ctx, args, _flags) => {
 
   const situational = await resolveSituational(ctx.baseDir)
   const persona = activatePersona(file, situational)
-  output(ctx, persona, formatPersona)
+
+  // Fire the persona.activated event. Hook stdout is appended to the
+  // rendered body in human mode, and to the wrapper object in JSON mode.
+  // Design + catalog: tnezdev/spores#26.
+  const hook = await fireHook(
+    "persona.activated",
+    {
+      SPORES_PERSONA_NAME: persona.name,
+      SPORES_PERSONA_MEMORY_TAGS: persona.memory_tags.join(","),
+      SPORES_PERSONA_SKILLS: persona.skills.join(","),
+      SPORES_PERSONA_WORKFLOW: persona.workflow ?? "",
+    },
+    ctx.baseDir,
+  )
+
+  const result: PersonaActivationOutput = {
+    persona,
+    hook: hook.ran ? hook : undefined,
+  }
+  output(ctx, result, formatPersonaActivation)
+
+  // Hook diagnostics go to stderr regardless of output mode — they're side
+  // channels, not payload. Non-zero exit or timeout is a warning, not a
+  // failure: the persona activation itself succeeded.
+  if (hook.ran) {
+    if (hook.stderr.length > 0) {
+      process.stderr.write(hook.stderr)
+    }
+    if (hook.error !== undefined) {
+      process.stderr.write(
+        `[hook warning] persona.activated: ${hook.error}\n`,
+      )
+    } else if (hook.exit_code !== null && hook.exit_code !== 0) {
+      process.stderr.write(
+        `[hook warning] persona.activated exited ${hook.exit_code}\n`,
+      )
+    }
+  }
 }

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -10,6 +10,7 @@ import type {
   SkillRef,
   Task,
   Persona,
+  PersonaActivationOutput,
   PersonaFile,
   PersonaRef,
 } from "../types.js"
@@ -216,4 +217,22 @@ export function formatPersona(persona: Persona): string {
   // Activated output is meant to be piped into an LLM — the body is the
   // payload. Emit the body only, not the metadata header.
   return persona.body
+}
+
+/**
+ * Human formatter for `persona activate`: the rendered body followed by the
+ * stdout of a `persona.activated` hook if one ran and produced output. JSON
+ * mode serializes the whole wrapper structurally; this formatter only runs
+ * in human mode (see `output()` in src/cli/output.ts).
+ */
+export function formatPersonaActivation(
+  result: PersonaActivationOutput,
+): string {
+  const parts = [formatPersona(result.persona)]
+  const hook = result.hook
+  if (hook !== undefined && hook.ran && hook.stdout.trim().length > 0) {
+    parts.push("\n---\n")
+    parts.push(hook.stdout.trimEnd())
+  }
+  return parts.join("\n")
 }

--- a/src/cli/main.test.ts
+++ b/src/cli/main.test.ts
@@ -500,14 +500,55 @@ The cwd is {{cwd}}.
         "spores-maintainer.md",
         SAMPLE,
       )
-      const persona = (await runPersonaJson(
+      // activate wraps the rendered persona in a PersonaActivationOutput
+      // alongside any hook result (see tnezdev/spores#27). The persona
+      // lives under `.persona`; the hook is undefined when no hook fired.
+      const result = (await runPersonaJson(
         ...base,
         "persona",
         "activate",
         "spores-maintainer",
-      )) as { body: string; situational: { cwd: string } }
-      expect(persona.body).not.toContain("{{cwd}}") // substituted
-      expect(persona.body).toContain(persona.situational.cwd)
+      )) as {
+        persona: { body: string; situational: { cwd: string } }
+        hook?: unknown
+      }
+      expect(result.persona.body).not.toContain("{{cwd}}") // substituted
+      expect(result.persona.body).toContain(result.persona.situational.cwd)
+      expect(result.hook).toBeUndefined()
+    })
+
+    it("activate fires persona.activated hook and appends its stdout", async () => {
+      await writePersona(
+        join(tmpDir, ".spores", "personas"),
+        "spores-maintainer.md",
+        SAMPLE,
+      )
+      // Write an executable hook that echoes env vars — this exercises
+      // event firing, env propagation, and output wrapping together.
+      const hookDir = join(tmpDir, ".spores", "hooks")
+      await mkdir(hookDir, { recursive: true })
+      const hookPath = join(hookDir, "persona.activated")
+      await writeFile(
+        hookPath,
+        '#!/usr/bin/env bash\necho "event=$SPORES_EVENT"\necho "name=$SPORES_PERSONA_NAME"\necho "tags=$SPORES_PERSONA_MEMORY_TAGS"\n',
+      )
+      const { chmod } = await import("node:fs/promises")
+      await chmod(hookPath, 0o755)
+
+      const result = (await runPersonaJson(
+        ...base,
+        "persona",
+        "activate",
+        "spores-maintainer",
+      )) as {
+        persona: { body: string }
+        hook: { ran: boolean; stdout: string; exit_code: number | null }
+      }
+      expect(result.hook.ran).toBe(true)
+      expect(result.hook.exit_code).toBe(0)
+      expect(result.hook.stdout).toContain("event=persona.activated")
+      expect(result.hook.stdout).toContain("name=spores-maintainer")
+      expect(result.hook.stdout).toContain("tags=spores,npm")
     })
 
     it("view fails on missing persona", async () => {

--- a/src/hooks/fire.test.ts
+++ b/src/hooks/fire.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test"
+import { mkdtemp, rm, mkdir, writeFile, chmod } from "node:fs/promises"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { fireHook } from "./fire.js"
+
+async function writeHook(
+  hookDir: string,
+  event: string,
+  script: string,
+  mode = 0o755,
+): Promise<string> {
+  await mkdir(hookDir, { recursive: true })
+  const path = join(hookDir, event)
+  await writeFile(path, script)
+  await chmod(path, mode)
+  return path
+}
+
+describe("hooks/fireHook", () => {
+  let tmpDir: string
+  let hookDir: string
+  const prevHooksDir = process.env["SPORES_HOOKS_DIR"]
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "spores-hooks-test-"))
+    hookDir = join(tmpDir, "hooks")
+    process.env["SPORES_HOOKS_DIR"] = hookDir
+  })
+
+  afterEach(async () => {
+    if (prevHooksDir === undefined) delete process.env["SPORES_HOOKS_DIR"]
+    else process.env["SPORES_HOOKS_DIR"] = prevHooksDir
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it("returns ran:false when no hook exists", async () => {
+    const result = await fireHook("persona.activated", {}, tmpDir)
+
+    expect(result.ran).toBe(false)
+    expect(result.stdout).toBe("")
+    expect(result.stderr).toBe("")
+    expect(result.exit_code).toBe(null)
+    expect(result.error).toBeUndefined()
+  })
+
+  it("returns ran:false when hook file exists but is not executable", async () => {
+    await writeHook(
+      hookDir,
+      "persona.activated",
+      "#!/usr/bin/env bash\necho should-not-run\n",
+      0o644,
+    )
+
+    const result = await fireHook("persona.activated", {}, tmpDir)
+
+    expect(result.ran).toBe(false)
+    expect(result.stdout).toBe("")
+  })
+
+  it("executes an executable hook and captures stdout", async () => {
+    await writeHook(
+      hookDir,
+      "persona.activated",
+      "#!/usr/bin/env bash\necho recalled-memory-1\necho recalled-memory-2\n",
+    )
+
+    const result = await fireHook("persona.activated", {}, tmpDir)
+
+    expect(result.ran).toBe(true)
+    expect(result.exit_code).toBe(0)
+    expect(result.stdout).toContain("recalled-memory-1")
+    expect(result.stdout).toContain("recalled-memory-2")
+    expect(result.error).toBeUndefined()
+  })
+
+  it("passes caller env vars into the hook process", async () => {
+    await writeHook(
+      hookDir,
+      "persona.activated",
+      '#!/usr/bin/env bash\necho "name=$SPORES_PERSONA_NAME"\necho "tags=$SPORES_PERSONA_MEMORY_TAGS"\necho "event=$SPORES_EVENT"\n',
+    )
+
+    const result = await fireHook(
+      "persona.activated",
+      {
+        SPORES_PERSONA_NAME: "spores-maintainer",
+        SPORES_PERSONA_MEMORY_TAGS: "spores,release",
+      },
+      tmpDir,
+    )
+
+    expect(result.ran).toBe(true)
+    expect(result.stdout).toContain("name=spores-maintainer")
+    expect(result.stdout).toContain("tags=spores,release")
+    expect(result.stdout).toContain("event=persona.activated")
+  })
+
+  it("injects SPORES_BIN when the caller does not set it", async () => {
+    await writeHook(
+      hookDir,
+      "persona.activated",
+      '#!/usr/bin/env bash\necho "bin=${SPORES_BIN:-unset}"\n',
+    )
+
+    const result = await fireHook("persona.activated", {}, tmpDir)
+
+    expect(result.ran).toBe(true)
+    // SPORES_BIN should be populated from process.argv[1] (the test runner).
+    expect(result.stdout).toMatch(/bin=.+/)
+    expect(result.stdout).not.toContain("bin=unset")
+  })
+
+  it("surfaces non-zero exit codes without throwing", async () => {
+    await writeHook(
+      hookDir,
+      "persona.activated",
+      "#!/usr/bin/env bash\necho partial-output\nexit 3\n",
+    )
+
+    const result = await fireHook("persona.activated", {}, tmpDir)
+
+    expect(result.ran).toBe(true)
+    expect(result.exit_code).toBe(3)
+    expect(result.stdout).toContain("partial-output")
+    expect(result.error).toBeUndefined()
+  })
+
+  it("kills hooks that exceed the timeout and returns an error", async () => {
+    await writeHook(
+      hookDir,
+      "persona.activated",
+      "#!/usr/bin/env bash\nsleep 30\n",
+    )
+
+    const result = await fireHook("persona.activated", {}, tmpDir)
+
+    expect(result.ran).toBe(true)
+    expect(result.error).toMatch(/timed out/)
+  }, 15000)
+
+  it("project hook wins over user hook when both exist", async () => {
+    // Override the test-env pointer and use the real project/user dirs
+    // rooted under tmpDir.
+    delete process.env["SPORES_HOOKS_DIR"]
+
+    const projectHookDir = join(tmpDir, "project", ".spores", "hooks")
+    const userHome = join(tmpDir, "home")
+    const userHookDir = join(userHome, ".spores", "hooks")
+    const prevHome = process.env["HOME"]
+    process.env["HOME"] = userHome
+
+    try {
+      await writeHook(
+        projectHookDir,
+        "persona.activated",
+        "#!/usr/bin/env bash\necho from-project\n",
+      )
+      await writeHook(
+        userHookDir,
+        "persona.activated",
+        "#!/usr/bin/env bash\necho from-user\n",
+      )
+
+      const result = await fireHook(
+        "persona.activated",
+        {},
+        join(tmpDir, "project"),
+      )
+
+      expect(result.ran).toBe(true)
+      expect(result.stdout).toContain("from-project")
+      expect(result.stdout).not.toContain("from-user")
+    } finally {
+      if (prevHome === undefined) delete process.env["HOME"]
+      else process.env["HOME"] = prevHome
+      process.env["SPORES_HOOKS_DIR"] = hookDir
+    }
+  })
+
+  it("uses user hook when project hook is absent", async () => {
+    delete process.env["SPORES_HOOKS_DIR"]
+
+    const userHome = join(tmpDir, "home")
+    const userHookDir = join(userHome, ".spores", "hooks")
+    const prevHome = process.env["HOME"]
+    process.env["HOME"] = userHome
+
+    try {
+      await writeHook(
+        userHookDir,
+        "persona.activated",
+        "#!/usr/bin/env bash\necho from-user-fallback\n",
+      )
+
+      const result = await fireHook(
+        "persona.activated",
+        {},
+        join(tmpDir, "project"),
+      )
+
+      expect(result.ran).toBe(true)
+      expect(result.stdout).toContain("from-user-fallback")
+    } finally {
+      if (prevHome === undefined) delete process.env["HOME"]
+      else process.env["HOME"] = prevHome
+      process.env["SPORES_HOOKS_DIR"] = hookDir
+    }
+  })
+})

--- a/src/hooks/fire.ts
+++ b/src/hooks/fire.ts
@@ -1,0 +1,164 @@
+import { existsSync, statSync } from "node:fs"
+import { homedir } from "node:os"
+import { join } from "node:path"
+import type { HookInvocation } from "../types.js"
+
+/**
+ * Fire a spores primitive event. Events are named `<primitive>.<verb>`
+ * (e.g. `persona.activated`, `task.done`). Event firing is synchronous,
+ * in-process, and happens *after* the primary verb's effect has been
+ * written — the hook cannot prevent or alter the verb's outcome.
+ *
+ * Hook lookup (first match wins):
+ *   1. `$SPORES_HOOKS_DIR/<event>` — test override; if set, nothing else is consulted
+ *   2. `<baseDir>/.spores/hooks/<event>` — project-level
+ *   3. `~/.spores/hooks/<event>` — user-level
+ *
+ * A hook is considered present only if the file exists AND has at least
+ * one executable bit set (owner/group/other). Presence without the exec
+ * bit is treated as "not a hook" — avoids accidentally running editor
+ * scratch files or templates.
+ *
+ * Design rationale + event catalog: tnezdev/spores#26
+ * Minimum experiment (this verb only): tnezdev/spores#27
+ */
+
+const TIMEOUT_MS = 5000
+
+function userHome(): string {
+  return process.env["HOME"] ?? homedir()
+}
+
+function hookDirs(baseDir: string): string[] {
+  const override = process.env["SPORES_HOOKS_DIR"]
+  if (override !== undefined && override !== "") return [override]
+  return [
+    join(baseDir, ".spores", "hooks"),
+    join(userHome(), ".spores", "hooks"),
+  ]
+}
+
+function isExecutableFile(path: string): boolean {
+  try {
+    const s = statSync(path)
+    if (!s.isFile()) return false
+    return (s.mode & 0o111) !== 0
+  } catch {
+    return false
+  }
+}
+
+function resolveHook(event: string, baseDir: string): string | undefined {
+  for (const dir of hookDirs(baseDir)) {
+    const candidate = join(dir, event)
+    if (existsSync(candidate) && isExecutableFile(candidate)) return candidate
+  }
+  return undefined
+}
+
+/**
+ * Fire the named event. If no hook is present, returns a quiet no-op result
+ * (`ran: false`). If a hook is present, it is executed with the provided env
+ * vars merged into the current process env, plus an injected `SPORES_EVENT`
+ * and (if not already set) a `SPORES_BIN` pointing at the current CLI entry.
+ *
+ * Hooks run with a 5-second timeout. Timeouts and non-zero exits are surfaced
+ * via the `error` / `exit_code` fields on the result — they are not thrown.
+ * Callers decide how to present warnings to the user.
+ */
+export async function fireHook(
+  event: string,
+  env: Record<string, string>,
+  baseDir: string,
+): Promise<HookInvocation> {
+  const script = resolveHook(event, baseDir)
+  if (script === undefined) {
+    return {
+      event,
+      ran: false,
+      stdout: "",
+      stderr: "",
+      exit_code: null,
+    }
+  }
+
+  const fullEnv: Record<string, string> = {
+    ...(process.env as Record<string, string>),
+    ...env,
+    SPORES_EVENT: event,
+  }
+
+  if (fullEnv["SPORES_BIN"] === undefined || fullEnv["SPORES_BIN"] === "") {
+    fullEnv["SPORES_BIN"] = process.argv[1] ?? "spores"
+  }
+
+  try {
+    const proc = Bun.spawn([script], {
+      env: fullEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    })
+
+    // Race the hook's exit against a timer. On timeout we kill the process
+    // but do NOT await further cleanup — children (e.g. a `sleep` inside a
+    // shell script) may outlive the parent's signal handling and keep the
+    // pipes open, which would hang `proc.exited` and `Response.text()`.
+    // The contract is: hooks either finish in time or they lose the result
+    // window. The OS can clean up stragglers.
+    //
+    // CRITICAL: capture the timer handle and clearTimeout on the winning
+    // path. An un-cleared pending timer keeps Bun's event loop alive and
+    // prevents the caller's process from exiting — manifests as "spores
+    // command hangs" when spores is itself spawned as a subprocess
+    // (terminals mask it via tty/exec semantics; Bun.spawn exposes it).
+    const TIMEOUT_SENTINEL: unique symbol = Symbol("hook-timeout") as never
+    type Winner = number | typeof TIMEOUT_SENTINEL
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const timeoutPromise: Promise<Winner> = new Promise((resolve) => {
+      timer = setTimeout(() => resolve(TIMEOUT_SENTINEL), TIMEOUT_MS)
+    })
+
+    const winner = await Promise.race<Winner>([proc.exited, timeoutPromise])
+    if (timer !== undefined) clearTimeout(timer)
+
+    if (winner === TIMEOUT_SENTINEL) {
+      try {
+        proc.kill()
+      } catch {
+        // Process may have already exited.
+      }
+      return {
+        event,
+        ran: true,
+        stdout: "",
+        stderr: "",
+        exit_code: null,
+        error: `hook timed out after ${TIMEOUT_MS}ms`,
+      }
+    }
+
+    const exitCode = winner
+    const [stdout, stderr] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ])
+
+    return {
+      event,
+      ran: true,
+      stdout,
+      stderr,
+      exit_code: exitCode,
+    }
+  } catch (err) {
+    return {
+      event,
+      ran: true,
+      stdout: "",
+      stderr: "",
+      exit_code: null,
+      error: err instanceof Error ? err.message : String(err),
+    }
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -232,3 +232,34 @@ export type Persona = PersonaRef & {
   situational: SituationalContext
   path: string
 }
+
+// ---------------------------------------------------------------------------
+// Hook types
+// ---------------------------------------------------------------------------
+
+/**
+ * Result of firing a hook script. `ran: false` means no hook was found or it
+ * was not executable — a non-error quiet no-op. `ran: true` with a non-zero
+ * `exit_code` or an `error` string means the hook ran but failed; by design
+ * this is a warning, not a fatal error — the primary verb still succeeds.
+ *
+ * See tnezdev/spores#26 for the design rationale and event catalog.
+ */
+export type HookInvocation = {
+  event: string
+  ran: boolean
+  stdout: string
+  stderr: string
+  exit_code: number | null
+  error?: string | undefined
+}
+
+/**
+ * Output of `persona activate`: the rendered persona plus the result of any
+ * `persona.activated` hook that fired. The hook's stdout is appended to the
+ * human-formatted activation output; JSON mode serializes the whole wrapper.
+ */
+export type PersonaActivationOutput = {
+  persona: Persona
+  hook?: HookInvocation | undefined
+}


### PR DESCRIPTION
Ships the minimum experiment from #27 (design in #26). Spores primitives fire their own events; handlers compose other primitives. The first wiring realizes the persona `memory_tags` binding from #16 via a hook rather than a runtime composition object — we may or may not need the composition object after this.

## Summary

- **`src/hooks/fire.ts`** — new `fireHook(event, env, baseDir)` helper. Git-hooks-style lookup: project-level `.spores/hooks/<event>` wins over `~/.spores/hooks/<event>`; presence + executable bit required; `SPORES_HOOKS_DIR` override for tests. 5s timeout via `Promise.race` against `proc.exited`. Non-zero exits and timeouts surface as warnings on the result, never thrown.
- **Critical gotcha captured in the code** — the timer handle is cleared on the winning path. Without `clearTimeout`, a pending `setTimeout` keeps Bun's event loop alive and the CLI hangs when spawned as a subprocess (terminals mask this via tty/exec; `Bun.spawn` exposes it). Caught live while writing the CLI integration test; comment in `fire.ts` explains the trap.
- **`src/cli/commands/persona.ts`** — `persona activate` fires `persona.activated` after the body is rendered, with env vars `SPORES_EVENT`, `SPORES_BIN`, `SPORES_PERSONA_NAME`, `SPORES_PERSONA_MEMORY_TAGS`, `SPORES_PERSONA_SKILLS`, `SPORES_PERSONA_WORKFLOW`. Stdout is appended to the rendered body in human mode and to the wrapper object in JSON mode.
- **`src/types.ts`** — new `HookInvocation` and `PersonaActivationOutput` types. `persona activate --json` now emits `{ persona, hook }`; `hook` is `undefined` when no hook fired. This is a pre-1.0 shape break, intentional.
- **`.spores/hooks/persona.activated`** — the dogfood handler. Reads `SPORES_PERSONA_MEMORY_TAGS` and calls back into `spores memory recall --tag <each>`. Tested end-to-end: activating `spores-maintainer` now inlines the three L1 facts about runtime scope, repo identity, and the v0.1 publish path below the rendered body.
- **`.spores/personas/spores-maintainer.md`** — the old "Current state — don't encode a snapshot here" hedge is gone, replaced with a "Durable context" note pointing at the hook. Rules live in the body; facts live in memory.
- **`.spores/ONRAMP.md`** — the `persona activate` description mentions the hook so the on-ramp matches actual behavior.

## Why this matters

The bridge.md lesson we keep relearning: *any process that depends on "remembering to do X" will fail; any process that makes X the default path will succeed*. The dogfood's ONRAMP patched session entry. Hooks patch the primitive-to-primitive composition that was otherwise sitting in the persona frontmatter as declarative metadata nobody consulted. Now activation **actually does** what `memory_tags` implies.

Hooks are deliberately not modeled on Claude Code's `SessionStart`/`Stop`. Spores has no session concept — per `AGENTS.md`, introducing one would be a scope violation. Host lifecycle maps to spores imperatives; imperatives fire spores events; events run handlers; handlers compose primitives. Clean separation.

## Test plan

- [x] `bun test` — 210 pass, 0 fail (new: 9 unit tests for `fireHook`, 1 integration test for `persona activate` with a mock hook)
- [x] `bun run typecheck` — clean
- [x] End-to-end dogfood: `bun src/cli/main.ts persona activate spores-maintainer` renders the persona body, a `---` separator, and three recalled memories from L1. Verified in the branch.
- [x] Task `01KNSYAM3WXBJG4YD92PE6D3BQ` marked done via `spores task done`.

## Not in scope

- Other events (`task.done`, `workflow.run.terminated`, etc.) — follow-up ready issues per #26.
- `.d/` directory form for multiple handlers per event — single script file only.
- `.spores/hooks/.ignore` — post-v0.
- Auto-cleanup of the known stale `.spores/tasks/BOGUS.json` warning — orthogonal, separate PR.

## Relationship to open issues

- Closes #27
- References #26 (design, stays open for the remaining events)
- References #16 (composition object — **deliberately not closed**; let lived experience with the hook decide whether a composition object is still needed)