### PR TITLE
chore: release v0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tnezdev/spores",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Executable toolbelt for agent self-improvement",
   "license": "MIT",
   "type": "module",

--- a/src/cli/commands/wake.test.ts
+++ b/src/cli/commands/wake.test.ts
@@ -33,6 +33,12 @@ async function runWakeJson(
   return JSON.parse(stdout)
 }
 
+async function writeConfig(baseDir: string, toml: string): Promise<void> {
+  const configDir = join(baseDir, ".spores")
+  await mkdir(configDir, { recursive: true })
+  await writeFile(join(configDir, "config.toml"), toml)
+}
+
 describe("wake", () => {
   let tmpDir: string
 
@@ -44,109 +50,106 @@ describe("wake", () => {
     await rm(tmpDir, { recursive: true })
   })
 
-  it("outputs environment even with no config", async () => {
-    const result = (await runWakeJson(tmpDir)) as {
-      situational: { hostname: string; cwd: string; timestamp: string }
-      personas: unknown[]
-    }
-    expect(result.situational.hostname).toBeDefined()
-    expect(result.situational.cwd).toBe(tmpDir)
-    expect(result.situational.timestamp).toBeDefined()
-    expect(result.personas).toEqual([])
-  })
-
-  it("human mode shows no-identity hint when unconfigured", async () => {
+  it("outputs default template when unconfigured", async () => {
     const { stdout, exitCode } = await runWake(tmpDir)
     expect(exitCode).toBe(0)
-    expect(stdout).toContain("no identity configured")
+    expect(stdout).toContain("no wake template configured")
+    expect(stdout).toContain("# Environment")
   })
 
-  it("reads identity file when configured", async () => {
-    const identityContent = "# Test Agent\n\nI am a test agent."
-    await writeFile(join(tmpDir, "identity.md"), identityContent)
-
-    const configDir = join(tmpDir, ".spores")
-    await mkdir(configDir, { recursive: true })
+  it("renders static tokens in template", async () => {
     await writeFile(
-      join(configDir, "config.toml"),
-      '[wake]\nidentity = "identity.md"\n',
+      join(tmpDir, "WAKE.md"),
+      "host={{hostname}} cwd={{cwd}} branch={{git_branch}} time={{timestamp}}",
     )
+    await writeConfig(tmpDir, '[wake]\ntemplate = "WAKE.md"\n')
 
     const result = (await runWakeJson(tmpDir)) as {
-      identity: string
-      identity_path: string
+      rendered: string
+      situational: { hostname: string; cwd: string }
     }
-    expect(result.identity).toBe(identityContent)
-    expect(result.identity_path).toBe(join(tmpDir, "identity.md"))
+    expect(result.rendered).toContain(`host=${result.situational.hostname}`)
+    expect(result.rendered).toContain(`cwd=${tmpDir}`)
+    expect(result.rendered).not.toContain("{{hostname}}")
+    expect(result.rendered).not.toContain("{{cwd}}")
   })
 
-  it("identity is undefined when file does not exist", async () => {
-    const configDir = join(tmpDir, ".spores")
-    await mkdir(configDir, { recursive: true })
+  it("executes {{sh:...}} expressions", async () => {
     await writeFile(
-      join(configDir, "config.toml"),
-      '[wake]\nidentity = "missing.md"\n',
+      join(tmpDir, "WAKE.md"),
+      "name={{sh:echo hello-world}}",
     )
+    await writeConfig(tmpDir, '[wake]\ntemplate = "WAKE.md"\n')
+
+    const result = (await runWakeJson(tmpDir)) as { rendered: string }
+    expect(result.rendered).toBe("name=hello-world")
+  })
+
+  it("{{sh:cat ...}} inlines file content", async () => {
+    await writeFile(join(tmpDir, "identity.md"), "# I am the agent")
+    await writeFile(
+      join(tmpDir, "WAKE.md"),
+      "{{sh:cat identity.md}}\n\nMore content.",
+    )
+    await writeConfig(tmpDir, '[wake]\ntemplate = "WAKE.md"\n')
+
+    const result = (await runWakeJson(tmpDir)) as { rendered: string }
+    expect(result.rendered).toContain("# I am the agent")
+    expect(result.rendered).toContain("More content.")
+  })
+
+  it("shows error inline when shell command fails", async () => {
+    await writeFile(
+      join(tmpDir, "WAKE.md"),
+      "result={{sh:cat nonexistent-file.txt}}",
+    )
+    await writeConfig(tmpDir, '[wake]\ntemplate = "WAKE.md"\n')
+
+    const result = (await runWakeJson(tmpDir)) as { rendered: string }
+    // Should contain error text, not crash
+    expect(result.rendered).toContain("result=")
+    expect(result.rendered).toContain("No such file")
+  })
+
+  it("shell commands run with cwd set to baseDir", async () => {
+    await writeFile(join(tmpDir, "marker.txt"), "cwd-ok")
+    await writeFile(join(tmpDir, "WAKE.md"), "{{sh:cat marker.txt}}")
+    await writeConfig(tmpDir, '[wake]\ntemplate = "WAKE.md"\n')
+
+    const result = (await runWakeJson(tmpDir)) as { rendered: string }
+    expect(result.rendered).toBe("cwd-ok")
+  })
+
+  it("template_path is set in JSON output", async () => {
+    await writeFile(join(tmpDir, "WAKE.md"), "hello")
+    await writeConfig(tmpDir, '[wake]\ntemplate = "WAKE.md"\n')
 
     const result = (await runWakeJson(tmpDir)) as {
-      identity?: string
-      identity_path: string
+      template_path: string
     }
-    expect(result.identity).toBeUndefined()
-    expect(result.identity_path).toBe(join(tmpDir, "missing.md"))
+    expect(result.template_path).toBe(join(tmpDir, "WAKE.md"))
   })
 
-  it("supports absolute identity path", async () => {
-    const identityFile = join(tmpDir, "elsewhere", "me.md")
-    await mkdir(join(tmpDir, "elsewhere"), { recursive: true })
-    await writeFile(identityFile, "I exist elsewhere.")
-
-    const configDir = join(tmpDir, ".spores")
-    await mkdir(configDir, { recursive: true })
-    await writeFile(
-      join(configDir, "config.toml"),
-      `[wake]\nidentity = "${identityFile}"\n`,
+  it("supports absolute template path", async () => {
+    const elsewhere = join(tmpDir, "elsewhere")
+    await mkdir(elsewhere, { recursive: true })
+    await writeFile(join(elsewhere, "boot.md"), "booted from {{hostname}}")
+    await writeConfig(
+      tmpDir,
+      `[wake]\ntemplate = "${join(elsewhere, "boot.md")}"\n`,
     )
 
-    const result = (await runWakeJson(tmpDir)) as {
-      identity: string
-      identity_path: string
-    }
-    expect(result.identity).toBe("I exist elsewhere.")
-    expect(result.identity_path).toBe(identityFile)
+    const result = (await runWakeJson(tmpDir)) as { rendered: string }
+    expect(result.rendered).not.toContain("{{hostname}}")
+    expect(result.rendered).toContain("booted from")
   })
 
-  it("lists project personas", async () => {
-    const personaDir = join(tmpDir, ".spores", "personas")
-    await mkdir(personaDir, { recursive: true })
-    await writeFile(
-      join(personaDir, "developer.md"),
-      "---\nname: developer\ndescription: Write code\n---\n\nYou write code.\n",
-    )
+  it("unknown tokens are left literal", async () => {
+    await writeFile(join(tmpDir, "WAKE.md"), "keep={{unknown_token}}")
+    await writeConfig(tmpDir, '[wake]\ntemplate = "WAKE.md"\n')
 
-    const result = (await runWakeJson(tmpDir)) as {
-      personas: Array<{ name: string; description: string }>
-    }
-    expect(result.personas).toHaveLength(1)
-    expect(result.personas[0]!.name).toBe("developer")
-    expect(result.personas[0]!.description).toBe("Write code")
-  })
-
-  it("human mode shows identity content first", async () => {
-    await writeFile(join(tmpDir, "me.md"), "# I am the agent")
-    const configDir = join(tmpDir, ".spores")
-    await mkdir(configDir, { recursive: true })
-    await writeFile(
-      join(configDir, "config.toml"),
-      '[wake]\nidentity = "me.md"\n',
-    )
-
-    const { stdout, exitCode } = await runWake(tmpDir)
-    expect(exitCode).toBe(0)
-    // Identity should appear before environment
-    const identityPos = stdout.indexOf("I am the agent")
-    const envPos = stdout.indexOf("# Environment")
-    expect(identityPos).toBeLessThan(envPos)
+    const result = (await runWakeJson(tmpDir)) as { rendered: string }
+    expect(result.rendered).toBe("keep={{unknown_token}}")
   })
 
   it("fires wake.completed hook", async () => {
@@ -155,7 +158,7 @@ describe("wake", () => {
     const hookPath = join(hookDir, "wake.completed")
     await writeFile(
       hookPath,
-      '#!/usr/bin/env bash\necho "event=$SPORES_EVENT"\necho "personas=$SPORES_WAKE_PERSONA_COUNT"\n',
+      '#!/usr/bin/env bash\necho "event=$SPORES_EVENT"\n',
     )
     await chmod(hookPath, 0o755)
 
@@ -165,6 +168,5 @@ describe("wake", () => {
     expect(result.hook.ran).toBe(true)
     expect(result.hook.exit_code).toBe(0)
     expect(result.hook.stdout).toContain("event=wake.completed")
-    expect(result.hook.stdout).toContain("personas=0")
   })
 })

--- a/src/cli/commands/wake.ts
+++ b/src/cli/commands/wake.ts
@@ -1,70 +1,50 @@
-import { readFile } from "node:fs/promises"
-import { isAbsolute, join } from "node:path"
 import { fireHook } from "../../hooks/fire.js"
-import { listPersonas } from "../../personas/filesystem.js"
 import { resolveSituational } from "../../personas/situational.js"
 import type { WakeOutput } from "../../types.js"
+import {
+  resolveTemplatePath,
+  readTemplate,
+  resolveTemplate,
+} from "../../wake/resolve.js"
 import { formatWake } from "../format.js"
 import type { Command } from "../main.js"
 import { output } from "../main.js"
 
-interface NodeError extends Error {
-  code?: string | undefined
-}
+const DEFAULT_TEMPLATE = `(no wake template configured — set [wake] template in .spores/config.toml)
 
-function isNodeError(err: unknown): err is NodeError {
-  return err instanceof Error
-}
+---
 
-/**
- * Resolve the identity file path. If the configured path is relative, resolve
- * it against baseDir. Returns undefined if no identity is configured.
- */
-function resolveIdentityPath(
-  baseDir: string,
-  configured?: string,
-): string | undefined {
-  if (configured === undefined) return undefined
-  return isAbsolute(configured) ? configured : join(baseDir, configured)
-}
+# Environment
 
-async function readIdentity(
-  path: string | undefined,
-): Promise<string | undefined> {
-  if (path === undefined) return undefined
-  try {
-    return await readFile(path, "utf-8")
-  } catch (err) {
-    if (isNodeError(err) && err.code === "ENOENT") return undefined
-    throw err
-  }
-}
+hostname: {{hostname}}
+cwd: {{cwd}}
+branch: {{git_branch}}
+time: {{timestamp}}`
 
 export const wakeCommand: Command = async (ctx, _args, _flags) => {
-  const identityPath = resolveIdentityPath(
+  const templatePath = resolveTemplatePath(
     ctx.baseDir,
-    ctx.config.wake.identity,
+    ctx.config.wake.template,
   )
-  const [identity, situational, personas] = await Promise.all([
-    readIdentity(identityPath),
-    resolveSituational(ctx.baseDir),
-    listPersonas(ctx.baseDir),
-  ])
+  const situational = await resolveSituational(ctx.baseDir)
+
+  const rawTemplate = await readTemplate(templatePath)
+  const template = rawTemplate ?? DEFAULT_TEMPLATE
+
+  const rendered = await resolveTemplate(template, situational, ctx.baseDir)
 
   const hook = await fireHook(
     "wake.completed",
     {
-      SPORES_WAKE_IDENTITY: identityPath ?? "",
-      SPORES_WAKE_PERSONA_COUNT: String(personas.length),
+      SPORES_WAKE_TEMPLATE: templatePath ?? "",
     },
     ctx.baseDir,
   )
 
   const result: WakeOutput = {
-    identity,
-    identity_path: identityPath,
+    rendered,
+    template_path: templatePath,
     situational,
-    personas,
     hook: hook.ran ? hook : undefined,
   }
   output(ctx, result, formatWake)

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -29,6 +29,7 @@ import type {
   WakeOutput,
 } from "../types.js"
 
+
 export function formatMemory(m: Memory): string {
   const tags = m.tags.length > 0 ? ` [${m.tags.join(", ")}]` : ""
   const source = m.source !== undefined ? `\n  source: ${m.source}` : ""
@@ -408,54 +409,16 @@ export function formatPersonaActivation(
 // ---------------------------------------------------------------------------
 
 /**
- * Human formatter for `spores wake`. Output is designed to be consumed by an
- * LLM at session start — readable, structured, and complete. Identity content
- * comes first (the most important context), then environment, then available
- * personas as a table with descriptions that serve as activation hints.
- * Design: tnezdev/spores#34.
+ * Human formatter for `spores wake`. The rendered template IS the output —
+ * the template author controls the structure. Hook stdout is appended if
+ * present. Design: tnezdev/spores#34.
  */
 export function formatWake(result: WakeOutput): string {
-  const sections: string[] = []
-
-  // Identity
-  if (result.identity !== undefined) {
-    sections.push(result.identity.trimEnd())
-  } else {
-    sections.push(
-      "(no identity configured — set [wake] identity in .spores/config.toml)",
-    )
-  }
-
-  // Environment
-  const env = result.situational
-  const envLines = [
-    "# Environment",
-    "",
-    `hostname: ${env.hostname}`,
-    `cwd: ${env.cwd}`,
-  ]
-  if (env.git_branch !== undefined) {
-    envLines.push(`branch: ${env.git_branch}`)
-  }
-  envLines.push(`time: ${env.timestamp}`)
-  sections.push(envLines.join("\n"))
-
-  // Personas
-  if (result.personas.length > 0) {
-    const personaLines = ["# Available personas", ""]
-    personaLines.push(
-      formatPersonaRefs(result.personas, true),
-    )
-    sections.push(personaLines.join("\n"))
-  } else {
-    sections.push("# Available personas\n\nNone found.")
-  }
-
-  // Hook output
+  const parts = [result.rendered]
   const hook = result.hook
   if (hook !== undefined && hook.ran && hook.stdout.trim().length > 0) {
-    sections.push(hook.stdout.trimEnd())
+    parts.push("\n---\n")
+    parts.push(hook.stdout.trimEnd())
   }
-
-  return sections.join("\n\n---\n\n")
+  return parts.join("\n")
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -83,7 +83,7 @@ function applyToml(config: SporesConfig, doc: TomlDoc): SporesConfig {
 
   const wake = doc["wake"]
   if (typeof wake === "object") {
-    if (wake["identity"] !== undefined) result.wake.identity = wake["identity"]
+    if (wake["template"] !== undefined) result.wake.template = wake["template"]
   }
 
   return result

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,7 +40,7 @@ export type SporesConfig = {
     runsDir: string
   }
   wake: {
-    identity?: string | undefined // path to identity file (absolute or relative to baseDir)
+    template?: string | undefined // path to WAKE.md template (absolute or relative to baseDir)
   }
 }
 
@@ -414,9 +414,8 @@ export type WorkflowRunTransitionedOutput = {
  * to activate. Design: tnezdev/spores#34.
  */
 export type WakeOutput = {
-  identity?: string | undefined // contents of the identity file, if configured
-  identity_path?: string | undefined // resolved path to the identity file
+  rendered: string // fully resolved template output
+  template_path?: string | undefined // resolved path to the template file
   situational: SituationalContext
-  personas: PersonaRef[]
   hook?: HookInvocation | undefined
 }

--- a/src/wake/resolve.test.ts
+++ b/src/wake/resolve.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import type { SituationalContext } from "../types.js"
+import { resolveTemplate, resolveTemplatePath } from "./resolve.js"
+
+const SITUATIONAL: SituationalContext = {
+  cwd: "/test/dir",
+  timestamp: "2026-04-12T00:00:00.000Z",
+  hostname: "test-host",
+  git_branch: "main",
+}
+
+describe("resolveTemplatePath", () => {
+  it("returns undefined when no path configured", () => {
+    expect(resolveTemplatePath("/base")).toBeUndefined()
+  })
+
+  it("resolves relative path against baseDir", () => {
+    expect(resolveTemplatePath("/base", "WAKE.md")).toBe("/base/WAKE.md")
+  })
+
+  it("keeps absolute path as-is", () => {
+    expect(resolveTemplatePath("/base", "/other/WAKE.md")).toBe(
+      "/other/WAKE.md",
+    )
+  })
+})
+
+describe("resolveTemplate", () => {
+  let tmpDir: string
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "spores-resolve-test-"))
+  })
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true })
+  })
+
+  it("substitutes static tokens", async () => {
+    const result = await resolveTemplate(
+      "host={{hostname}} cwd={{cwd}}",
+      SITUATIONAL,
+      tmpDir,
+    )
+    expect(result).toBe("host=test-host cwd=/test/dir")
+  })
+
+  it("substitutes git_branch as empty string when undefined", async () => {
+    const noGit = { ...SITUATIONAL, git_branch: undefined }
+    const result = await resolveTemplate(
+      "branch={{git_branch}}",
+      noGit,
+      tmpDir,
+    )
+    expect(result).toBe("branch=")
+  })
+
+  it("leaves unknown tokens literal", async () => {
+    const result = await resolveTemplate(
+      "{{unknown}}",
+      SITUATIONAL,
+      tmpDir,
+    )
+    expect(result).toBe("{{unknown}}")
+  })
+
+  it("executes shell expressions", async () => {
+    const result = await resolveTemplate(
+      "{{sh:echo hello}}",
+      SITUATIONAL,
+      tmpDir,
+    )
+    expect(result).toBe("hello")
+  })
+
+  it("shell runs in baseDir", async () => {
+    // Use cat on a known file rather than pwd, which resolves symlinks
+    // on macOS (/var → /private/var)
+    await writeFile(join(tmpDir, "marker.txt"), "found-it")
+    const result = await resolveTemplate(
+      "{{sh:cat marker.txt}}",
+      SITUATIONAL,
+      tmpDir,
+    )
+    expect(result).toBe("found-it")
+  })
+
+  it("inlines file content via cat", async () => {
+    await writeFile(join(tmpDir, "id.md"), "# Agent")
+    const result = await resolveTemplate(
+      "{{sh:cat id.md}}",
+      SITUATIONAL,
+      tmpDir,
+    )
+    expect(result).toBe("# Agent")
+  })
+
+  it("shows error for failed commands", async () => {
+    const result = await resolveTemplate(
+      "{{sh:cat no-such-file}}",
+      SITUATIONAL,
+      tmpDir,
+    )
+    expect(result).toContain("No such file")
+  })
+
+  it("deduplicates identical shell expressions", async () => {
+    const result = await resolveTemplate(
+      "{{sh:echo dup}} and {{sh:echo dup}}",
+      SITUATIONAL,
+      tmpDir,
+    )
+    expect(result).toBe("dup and dup")
+  })
+
+  it("handles mixed static and shell tokens", async () => {
+    const result = await resolveTemplate(
+      "host={{hostname}} echo={{sh:echo ok}}",
+      SITUATIONAL,
+      tmpDir,
+    )
+    expect(result).toBe("host=test-host echo=ok")
+  })
+})

--- a/src/wake/resolve.ts
+++ b/src/wake/resolve.ts
@@ -1,0 +1,134 @@
+import { readFile } from "node:fs/promises"
+import { isAbsolute, join } from "node:path"
+import type { SituationalContext } from "../types.js"
+
+interface NodeError extends Error {
+  code?: string | undefined
+}
+
+function isNodeError(err: unknown): err is NodeError {
+  return err instanceof Error
+}
+
+/**
+ * Resolve the template file path. Relative paths resolve against baseDir.
+ */
+export function resolveTemplatePath(
+  baseDir: string,
+  configured?: string,
+): string | undefined {
+  if (configured === undefined) return undefined
+  return isAbsolute(configured) ? configured : join(baseDir, configured)
+}
+
+/**
+ * Read the template file. Returns undefined if not found.
+ */
+export async function readTemplate(
+  path: string | undefined,
+): Promise<string | undefined> {
+  if (path === undefined) return undefined
+  try {
+    return await readFile(path, "utf-8")
+  } catch (err) {
+    if (isNodeError(err) && err.code === "ENOENT") return undefined
+    throw err
+  }
+}
+
+/**
+ * Resolve a wake template by substituting static tokens and executing
+ * shell expressions.
+ *
+ * Static tokens: {{cwd}}, {{hostname}}, {{timestamp}}, {{git_branch}}
+ * Shell expressions: {{sh:command}} — executed with cwd set to baseDir
+ *
+ * Shell expressions run sequentially. A failed command (non-zero exit)
+ * substitutes its stderr as the output so the agent sees the error.
+ * Unknown {{word}} tokens are left literal (same as persona activation).
+ */
+export async function resolveTemplate(
+  template: string,
+  situational: SituationalContext,
+  baseDir: string,
+): Promise<string> {
+  const staticTokens: Record<string, string> = {
+    cwd: situational.cwd,
+    timestamp: situational.timestamp,
+    hostname: situational.hostname,
+    git_branch: situational.git_branch ?? "",
+  }
+
+  // First pass: collect all {{sh:...}} expressions and their positions.
+  // We process them sequentially to avoid spawning many processes at once.
+  const shellPattern = /\{\{sh:(.+?)\}\}/g
+  const shellMatches: Array<{ full: string; command: string }> = []
+  let match: RegExpExecArray | null
+  while ((match = shellPattern.exec(template)) !== null) {
+    shellMatches.push({ full: match[0], command: match[1]! })
+  }
+
+  // Execute shell expressions and build a replacement map
+  const shellResults = new Map<string, string>()
+  for (const { full, command } of shellMatches) {
+    if (shellResults.has(full)) continue // dedup identical expressions
+    const result = await executeShell(command, baseDir)
+    shellResults.set(full, result)
+  }
+
+  // Apply shell replacements
+  let resolved = template
+  for (const [token, value] of shellResults) {
+    resolved = resolved.replaceAll(token, value)
+  }
+
+  // Apply static token replacements
+  resolved = resolved.replace(/\{\{(\w+)\}\}/g, (m, key: string) => {
+    if (key in staticTokens) return staticTokens[key]!
+    return m // unknown token — leave literal
+  })
+
+  return resolved
+}
+
+/**
+ * Resolve the spores binary invocation string. When running from source
+ * (bun src/cli/main.ts), this returns "bun <path>". When running from
+ * an installed binary, it returns the binary path directly.
+ *
+ * Injected as $SPORES_BIN into the shell environment so templates can
+ * use `$SPORES_BIN persona list` even when `spores` isn't on PATH.
+ */
+function resolveSporesBin(): string {
+  const entry = process.argv[1] ?? "spores"
+  if (entry.endsWith(".ts")) return `bun ${entry}`
+  return entry
+}
+
+async function executeShell(
+  command: string,
+  cwd: string,
+): Promise<string> {
+  try {
+    const proc = Bun.spawn(["sh", "-c", command], {
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...process.env,
+        SPORES_BIN: resolveSporesBin(),
+      },
+    })
+    const stdout = await new Response(proc.stdout).text()
+    const stderr = await new Response(proc.stderr).text()
+    const exitCode = await proc.exited
+
+    if (exitCode !== 0) {
+      return stderr.trim() || `(command failed with exit code ${exitCode})`
+    }
+    return stdout.trimEnd()
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    return `(shell error: ${message})`
+  }
+}


### PR DESCRIPTION
## Summary

- Wake template system: `WAKE.md` with `{{sh:...}}` shell expressions replaces hardcoded assembly
- `$SPORES_BIN` injected into template shell env for self-referencing

## Breaking

- `[wake] identity` config key renamed to `[wake] template`

## Validation

- [x] 273 tests pass, 0 fail
- [x] TypeScript clean
- [x] Smoke test passes
- [x] End-to-end: `spores wake --base-dir ~/Code/dottie-weaver/identity` renders WAKE.md with `{{sh:cat DOTTIE.md}}` and `{{sh:$SPORES_BIN persona list --wide}}`