### PR TITLE
feat: pluggable Source abstraction for persona loading

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -56,9 +56,16 @@ export type { PersonaAdapter } from "./personas/adapter.js"
 export {
   FilesystemPersonaAdapter,
   listPersonas,
+  listPersonasFromSource,
   loadPersona,
+  loadPersonaFromSource,
 } from "./personas/filesystem.js"
 export { activatePersona } from "./personas/activate.js"
 export { resolveSituational } from "./personas/situational.js"
+
+export type { Source, SourceRecord } from "./sources/source.js"
+export { InMemorySource } from "./sources/in-memory.js"
+export { FlatFileSource } from "./sources/flat-file.js"
+export { LayeredSource } from "./sources/layered.js"
 
 export { fireHook } from "./hooks/fire.js"

--- a/src/personas/filesystem.test.ts
+++ b/src/personas/filesystem.test.ts
@@ -2,10 +2,14 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test"
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { InMemorySource } from "../sources/in-memory.js"
+import { LayeredSource } from "../sources/layered.js"
 import {
   FilesystemPersonaAdapter,
   listPersonas,
+  listPersonasFromSource,
   loadPersona,
+  loadPersonaFromSource,
 } from "./filesystem.js"
 
 // We override HOME so the "global" personas dir points into a scratch tmp
@@ -282,5 +286,100 @@ describe("FilesystemPersonaAdapter", () => {
     expect(refs).toHaveLength(1)
     const file = await adapter.loadPersona("minimal")
     expect(file!.name).toBe("minimal")
+  })
+})
+
+describe("loadPersonaFromSource", () => {
+  test("loads a persona from any source — no filesystem coupling", async () => {
+    const source = new InMemorySource({ minimal: MINIMAL }, "test")
+    const file = await loadPersonaFromSource("minimal", source)
+    expect(file!.name).toBe("minimal")
+    expect(file!.description).toBe("Activate for minimal test coverage")
+    expect(file!.body.trim()).toBe("Body text.")
+    expect(file!.path).toBe("test:minimal")
+  })
+
+  test("returns undefined when the source has no record by that name", async () => {
+    const source = new InMemorySource({ alpha: MINIMAL })
+    const file = await loadPersonaFromSource("missing", source)
+    expect(file).toBeUndefined()
+  })
+
+  test("returns undefined when frontmatter is missing required fields", async () => {
+    const source = new InMemorySource({
+      broken: `---\ndescription: No name here\n---\nbody\n`,
+    })
+    const file = await loadPersonaFromSource("broken", source)
+    expect(file).toBeUndefined()
+  })
+
+  test("layered source: live state shadows seed", async () => {
+    const seed = new InMemorySource(
+      {
+        dup: `---\nname: dup\ndescription: Seed version\n---\nseed body\n`,
+      },
+      "seed",
+    )
+    const live = new InMemorySource(
+      {
+        dup: `---\nname: dup\ndescription: Live version\n---\nlive body\n`,
+      },
+      "live",
+    )
+    const layered = new LayeredSource([live, seed])
+    const file = await loadPersonaFromSource("dup", layered)
+    expect(file!.description).toBe("Live version")
+    expect(file!.body.trim()).toBe("live body")
+    expect(file!.path).toBe("live:dup")
+  })
+
+  test("layered source: falls through to seed when live lacks the name", async () => {
+    const seed = new InMemorySource(
+      {
+        seeded: `---\nname: seeded\ndescription: From seed\n---\nbody\n`,
+      },
+      "seed",
+    )
+    const live = new InMemorySource({}, "live")
+    const layered = new LayeredSource([live, seed])
+    const file = await loadPersonaFromSource("seeded", layered)
+    expect(file!.description).toBe("From seed")
+    expect(file!.path).toBe("seed:seeded")
+  })
+})
+
+describe("listPersonasFromSource", () => {
+  test("lists personas from any source", async () => {
+    const source = new InMemorySource({
+      alpha: `---\nname: alpha\ndescription: A\n---\n`,
+      zebra: `---\nname: zebra\ndescription: Z\n---\n`,
+    })
+    const refs = await listPersonasFromSource(source)
+    expect(refs.map((r) => r.name)).toEqual(["alpha", "zebra"])
+  })
+
+  test("skips records with missing required fields", async () => {
+    const source = new InMemorySource({
+      ok: `---\nname: ok\ndescription: ok\n---\n`,
+      broken: `---\ndescription: no name\n---\n`,
+    })
+    const refs = await listPersonasFromSource(source)
+    expect(refs.map((r) => r.name)).toEqual(["ok"])
+  })
+
+  test("layered source: unions and dedupes by name (live wins on read)", async () => {
+    const seed = new InMemorySource({
+      shared: `---\nname: shared\ndescription: Seed shared\n---\n`,
+      seedOnly: `---\nname: seedOnly\ndescription: Seed only\n---\n`,
+    })
+    const live = new InMemorySource({
+      shared: `---\nname: shared\ndescription: Live shared\n---\n`,
+      liveOnly: `---\nname: liveOnly\ndescription: Live only\n---\n`,
+    })
+    const layered = new LayeredSource([live, seed])
+    const refs = await listPersonasFromSource(layered)
+    expect(refs.map((r) => r.name)).toEqual(["liveOnly", "seedOnly", "shared"])
+    const sharedRef = refs.find((r) => r.name === "shared")!
+    expect(sharedRef.description).toBe("Live shared")
   })
 })

--- a/src/personas/filesystem.ts
+++ b/src/personas/filesystem.ts
@@ -1,21 +1,15 @@
-import { readdir, readFile } from "node:fs/promises"
 import { join } from "node:path"
 import { homedir } from "node:os"
 import type { PersonaFile, PersonaRef, TaskQuery, TaskStatus } from "../types.js"
+import type { Source } from "../sources/source.js"
+import { FlatFileSource } from "../sources/flat-file.js"
+import { LayeredSource } from "../sources/layered.js"
 import type { PersonaAdapter } from "./adapter.js"
 
 function userHome(): string {
   // Prefer HOME env var so tests can override it. Falls back to os.homedir()
   // which reads the system password database on Unix.
   return process.env["HOME"] ?? homedir()
-}
-
-interface NodeError extends Error {
-  code?: string | undefined
-}
-
-function isNodeError(err: unknown): err is NodeError {
-  return err instanceof Error
 }
 
 // ---------------------------------------------------------------------------
@@ -135,7 +129,7 @@ function parseFrontmatter(text: string): { meta: ParsedMeta; body: string } {
   return { meta, body }
 }
 
-function metaToRef(meta: ParsedMeta, path: string): PersonaRef | undefined {
+function metaToRef(meta: ParsedMeta): PersonaRef | undefined {
   if (meta.name === undefined || meta.description === undefined) return undefined
   return {
     name: meta.name,
@@ -148,7 +142,53 @@ function metaToRef(meta: ParsedMeta, path: string): PersonaRef | undefined {
 }
 
 // ---------------------------------------------------------------------------
-// Directory resolution
+// Source-based API — works with any pluggable Source
+// ---------------------------------------------------------------------------
+
+/**
+ * List all personas exposed by the given source. Skips records whose
+ * frontmatter is missing required fields (`name`, `description`) — those
+ * are surfaced quietly rather than throwing, matching `loadPersona`'s
+ * "return undefined for malformed" semantics.
+ */
+export async function listPersonasFromSource(
+  source: Source,
+): Promise<PersonaRef[]> {
+  const names = await source.list()
+  const refs: PersonaRef[] = []
+
+  for (const name of names) {
+    const record = await source.read(name)
+    if (record === undefined) continue
+
+    const { meta } = parseFrontmatter(record.text)
+    const ref = metaToRef(meta)
+    if (ref !== undefined) refs.push(ref)
+  }
+
+  return refs.sort((a, b) => a.name.localeCompare(b.name))
+}
+
+/**
+ * Load a single persona by name from a source. Returns undefined if the
+ * name is not found or the frontmatter is missing required fields.
+ */
+export async function loadPersonaFromSource(
+  name: string,
+  source: Source,
+): Promise<PersonaFile | undefined> {
+  const record = await source.read(name)
+  if (record === undefined) return undefined
+
+  const { meta, body } = parseFrontmatter(record.text)
+  const ref = metaToRef(meta)
+  if (ref === undefined) return undefined
+
+  return { ...ref, body, path: record.locator }
+}
+
+// ---------------------------------------------------------------------------
+// Convenience API — filesystem layering of project + global personas
 // ---------------------------------------------------------------------------
 
 function globalPersonasDir(): string {
@@ -159,79 +199,19 @@ function projectPersonasDir(baseDir: string): string {
   return join(baseDir, ".spores", "personas")
 }
 
-async function scanDir(dir: string): Promise<PersonaRef[]> {
-  let entries: string[]
-  try {
-    entries = await readdir(dir)
-  } catch (err) {
-    if (isNodeError(err) && err.code === "ENOENT") return []
-    throw err
-  }
-
-  const refs: PersonaRef[] = []
-
-  for (const entry of entries) {
-    if (!entry.endsWith(".md")) continue
-    const file = join(dir, entry)
-    let text: string
-    try {
-      text = await readFile(file, "utf-8")
-    } catch (err) {
-      if (isNodeError(err) && err.code === "ENOENT") continue
-      throw err
-    }
-
-    const { meta } = parseFrontmatter(text)
-    const ref = metaToRef(meta, file)
-    if (ref !== undefined) refs.push(ref)
-  }
-
-  return refs
+function defaultFilesystemSource(baseDir: string): Source {
+  return new LayeredSource([
+    new FlatFileSource(projectPersonasDir(baseDir), ".md"),
+    new FlatFileSource(globalPersonasDir(), ".md"),
+  ])
 }
-
-async function loadFromDir(
-  dir: string,
-  name: string,
-): Promise<PersonaFile | undefined> {
-  const file = join(dir, `${name}.md`)
-  let text: string
-  try {
-    text = await readFile(file, "utf-8")
-  } catch (err) {
-    if (isNodeError(err) && err.code === "ENOENT") return undefined
-    throw err
-  }
-
-  const { meta, body } = parseFrontmatter(text)
-  const ref = metaToRef(meta, file)
-  if (ref === undefined) return undefined
-
-  return {
-    ...ref,
-    body,
-    path: file,
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Public API — functional + class-based, mirroring skills
-// ---------------------------------------------------------------------------
 
 /**
  * List all available personas. Project personas (`.spores/personas/`) override
  * global personas (`~/.spores/personas/`) when names conflict.
  */
 export async function listPersonas(baseDir: string): Promise<PersonaRef[]> {
-  const [global, project] = await Promise.all([
-    scanDir(globalPersonasDir()),
-    scanDir(projectPersonasDir(baseDir)),
-  ])
-
-  const byName = new Map<string, PersonaRef>()
-  for (const ref of global) byName.set(ref.name, ref)
-  for (const ref of project) byName.set(ref.name, ref) // project wins
-
-  return Array.from(byName.values()).sort((a, b) => a.name.localeCompare(b.name))
+  return listPersonasFromSource(defaultFilesystemSource(baseDir))
 }
 
 /**
@@ -242,12 +222,7 @@ export async function loadPersona(
   name: string,
   baseDir: string,
 ): Promise<PersonaFile | undefined> {
-  const dirs = [projectPersonasDir(baseDir), globalPersonasDir()]
-  for (const dir of dirs) {
-    const file = await loadFromDir(dir, name)
-    if (file !== undefined) return file
-  }
-  return undefined
+  return loadPersonaFromSource(name, defaultFilesystemSource(baseDir))
 }
 
 /**

--- a/src/sources/flat-file.test.ts
+++ b/src/sources/flat-file.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { mkdir, mkdtemp, writeFile, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { FlatFileSource } from "./flat-file.js"
+
+let dir: string
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "spores-flat-file-"))
+})
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true })
+})
+
+describe("FlatFileSource", () => {
+  test("read returns text + absolute path locator", async () => {
+    const file = join(dir, "alpha.md")
+    await writeFile(file, "alpha-body")
+    const source = new FlatFileSource(dir)
+    const record = await source.read("alpha")
+    expect(record).toEqual({ text: "alpha-body", locator: file })
+  })
+
+  test("read returns undefined for missing file", async () => {
+    const source = new FlatFileSource(dir)
+    const record = await source.read("missing")
+    expect(record).toBeUndefined()
+  })
+
+  test("read returns undefined when directory does not exist", async () => {
+    const source = new FlatFileSource(join(dir, "nonexistent"))
+    const record = await source.read("alpha")
+    expect(record).toBeUndefined()
+  })
+
+  test("list returns names without extension, sorted", async () => {
+    await writeFile(join(dir, "zebra.md"), "z")
+    await writeFile(join(dir, "alpha.md"), "a")
+    await writeFile(join(dir, "mike.md"), "m")
+    const source = new FlatFileSource(dir)
+    expect(await source.list()).toEqual(["alpha", "mike", "zebra"])
+  })
+
+  test("list filters by extension", async () => {
+    await writeFile(join(dir, "alpha.md"), "a")
+    await writeFile(join(dir, "README.txt"), "x")
+    await writeFile(join(dir, "config.json"), "{}")
+    const source = new FlatFileSource(dir, ".md")
+    expect(await source.list()).toEqual(["alpha"])
+  })
+
+  test("list returns empty array when directory does not exist", async () => {
+    const source = new FlatFileSource(join(dir, "nonexistent"))
+    expect(await source.list()).toEqual([])
+  })
+
+  test("custom extension reads matching files", async () => {
+    await writeFile(join(dir, "graph.json"), '{"id":"x"}')
+    const source = new FlatFileSource(dir, ".json")
+    const record = await source.read("graph")
+    expect(record!.text).toBe('{"id":"x"}')
+  })
+
+  test("nested subdirectories are not surfaced", async () => {
+    await mkdir(join(dir, "subdir"))
+    await writeFile(join(dir, "subdir", "alpha.md"), "a")
+    await writeFile(join(dir, "top.md"), "t")
+    const source = new FlatFileSource(dir)
+    expect(await source.list()).toEqual(["top"])
+  })
+})

--- a/src/sources/flat-file.ts
+++ b/src/sources/flat-file.ts
@@ -1,0 +1,52 @@
+import { readdir, readFile } from "node:fs/promises"
+import { join } from "node:path"
+import type { Source, SourceRecord } from "./source.js"
+
+interface NodeError extends Error {
+  code?: string | undefined
+}
+
+function isNodeError(err: unknown): err is NodeError {
+  return err instanceof Error
+}
+
+/**
+ * A `Source` backed by a flat directory of `<name><ext>` files. Suits
+ * personas (`<dir>/<name>.md`) and workflows (`<dir>/<name>.json`). Skills
+ * use a different layout (`<dir>/<name>/skill.md`) and need their own source.
+ *
+ * Missing directory is treated as empty — `read` returns `undefined`,
+ * `list` returns `[]`. Other I/O errors throw.
+ */
+export class FlatFileSource implements Source {
+  constructor(
+    private readonly dir: string,
+    private readonly ext: string = ".md",
+  ) {}
+
+  async read(name: string): Promise<SourceRecord | undefined> {
+    const file = join(this.dir, `${name}${this.ext}`)
+    try {
+      const text = await readFile(file, "utf-8")
+      return { text, locator: file }
+    } catch (err) {
+      if (isNodeError(err) && err.code === "ENOENT") return undefined
+      throw err
+    }
+  }
+
+  async list(): Promise<string[]> {
+    let entries: string[]
+    try {
+      entries = await readdir(this.dir)
+    } catch (err) {
+      if (isNodeError(err) && err.code === "ENOENT") return []
+      throw err
+    }
+
+    return entries
+      .filter((e) => e.endsWith(this.ext))
+      .map((e) => e.slice(0, -this.ext.length))
+      .sort()
+  }
+}

--- a/src/sources/in-memory.test.ts
+++ b/src/sources/in-memory.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test"
+import { InMemorySource } from "./in-memory.js"
+
+describe("InMemorySource", () => {
+  test("read returns text + tagged locator for known names", async () => {
+    const source = new InMemorySource({ alpha: "alpha-body" }, "test")
+    const record = await source.read("alpha")
+    expect(record).toEqual({ text: "alpha-body", locator: "test:alpha" })
+  })
+
+  test("read returns undefined for unknown names", async () => {
+    const source = new InMemorySource({ alpha: "a" })
+    const record = await source.read("missing")
+    expect(record).toBeUndefined()
+  })
+
+  test("list returns sorted names", async () => {
+    const source = new InMemorySource({ zebra: "z", alpha: "a", mike: "m" })
+    const names = await source.list()
+    expect(names).toEqual(["alpha", "mike", "zebra"])
+  })
+
+  test("list returns empty array for empty source", async () => {
+    const source = new InMemorySource({})
+    const names = await source.list()
+    expect(names).toEqual([])
+  })
+
+  test("default tag is 'in-memory' when no tag is supplied", async () => {
+    const source = new InMemorySource({ alpha: "a" })
+    const record = await source.read("alpha")
+    expect(record!.locator).toBe("in-memory:alpha")
+  })
+})

--- a/src/sources/in-memory.ts
+++ b/src/sources/in-memory.ts
@@ -1,0 +1,26 @@
+import type { Source, SourceRecord } from "./source.js"
+
+/**
+ * A `Source` backed by an in-memory map. Intended for tests and for callers
+ * (e.g. seed templates baked into a build) that want a source with no I/O.
+ *
+ * The `tag` is incorporated into each record's locator so test failures can
+ * tell apart which in-memory source produced a given record when several are
+ * layered.
+ */
+export class InMemorySource implements Source {
+  constructor(
+    private readonly entries: Record<string, string>,
+    private readonly tag: string = "in-memory",
+  ) {}
+
+  async read(name: string): Promise<SourceRecord | undefined> {
+    const text = this.entries[name]
+    if (text === undefined) return undefined
+    return { text, locator: `${this.tag}:${name}` }
+  }
+
+  async list(): Promise<string[]> {
+    return Object.keys(this.entries).sort()
+  }
+}

--- a/src/sources/layered.test.ts
+++ b/src/sources/layered.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test"
+import { InMemorySource } from "./in-memory.js"
+import { LayeredSource } from "./layered.js"
+
+describe("LayeredSource", () => {
+  test("read: first source wins on name conflict", async () => {
+    const top = new InMemorySource({ shared: "from-top" }, "top")
+    const bottom = new InMemorySource({ shared: "from-bottom" }, "bottom")
+    const layered = new LayeredSource([top, bottom])
+    const record = await layered.read("shared")
+    expect(record).toEqual({ text: "from-top", locator: "top:shared" })
+  })
+
+  test("read: falls through to lower layers when top is missing", async () => {
+    const top = new InMemorySource({}, "top")
+    const bottom = new InMemorySource({ alpha: "bottom-body" }, "bottom")
+    const layered = new LayeredSource([top, bottom])
+    const record = await layered.read("alpha")
+    expect(record).toEqual({ text: "bottom-body", locator: "bottom:alpha" })
+  })
+
+  test("read: returns undefined when no layer has the name", async () => {
+    const layered = new LayeredSource([
+      new InMemorySource({ a: "1" }),
+      new InMemorySource({ b: "2" }),
+    ])
+    const record = await layered.read("nope")
+    expect(record).toBeUndefined()
+  })
+
+  test("list: unions all layers, dedupes, sorts", async () => {
+    const top = new InMemorySource({ alpha: "1", shared: "top-shared" })
+    const bottom = new InMemorySource({ shared: "bottom-shared", zebra: "9" })
+    const layered = new LayeredSource([top, bottom])
+    expect(await layered.list()).toEqual(["alpha", "shared", "zebra"])
+  })
+
+  test("list: returns empty array when no layers have names", async () => {
+    const layered = new LayeredSource([
+      new InMemorySource({}),
+      new InMemorySource({}),
+    ])
+    expect(await layered.list()).toEqual([])
+  })
+
+  test("read: works with a single layer", async () => {
+    const layered = new LayeredSource([
+      new InMemorySource({ alpha: "a" }, "only"),
+    ])
+    const record = await layered.read("alpha")
+    expect(record).toEqual({ text: "a", locator: "only:alpha" })
+  })
+
+  test("read: works with zero layers (returns undefined)", async () => {
+    const layered = new LayeredSource([])
+    const record = await layered.read("anything")
+    expect(record).toBeUndefined()
+  })
+})

--- a/src/sources/layered.ts
+++ b/src/sources/layered.ts
@@ -1,0 +1,33 @@
+import type { Source, SourceRecord } from "./source.js"
+
+/**
+ * Composes multiple sources into one. The first source in the list wins on
+ * `read` (live state shadows seed templates); `list` unions and dedupes
+ * names across all layers.
+ *
+ * This is the seed-then-emerge primitive: stack a live mutable source over
+ * an immutable seed source, and consumers see the union with live overrides.
+ *
+ * @example
+ *   new LayeredSource([liveDbSource, seedFsSource])
+ */
+export class LayeredSource implements Source {
+  constructor(private readonly sources: readonly Source[]) {}
+
+  async read(name: string): Promise<SourceRecord | undefined> {
+    for (const source of this.sources) {
+      const record = await source.read(name)
+      if (record !== undefined) return record
+    }
+    return undefined
+  }
+
+  async list(): Promise<string[]> {
+    const all = new Set<string>()
+    for (const source of this.sources) {
+      const names = await source.list()
+      for (const name of names) all.add(name)
+    }
+    return Array.from(all).sort()
+  }
+}

--- a/src/sources/source.ts
+++ b/src/sources/source.ts
@@ -1,0 +1,33 @@
+/**
+ * A pluggable source of named, text-shaped config records — personas, skills,
+ * workflows, dispatch configs. The source yields raw text by name; per-primitive
+ * loaders parse what comes back into the right shape.
+ *
+ * Sources are read-only. Mutation (creating, editing, deleting records) is
+ * out of scope — live evolution happens through memory-side writes or
+ * direct source-implementation methods, never through this interface.
+ *
+ * Sources are config primitives only. Data primitives (memory, artifacts,
+ * tasks) have query semantics and live behind their own adapter shapes.
+ */
+export interface Source {
+  /**
+   * Read a record by name. Returns `undefined` for not-found; throws on
+   * unexpected errors. The `locator` is a source-specific diagnostic
+   * identifier (filesystem path, URL, in-memory tag) — useful for error
+   * messages and for callers that want to surface where a record came from.
+   */
+  read(name: string): Promise<SourceRecord | undefined>
+
+  /**
+   * List all known names. Used for discovery (CLI `list` verbs, layered
+   * source union semantics). Should be cheap relative to `read` — name
+   * enumeration only, no body fetches.
+   */
+  list(): Promise<string[]>
+}
+
+export type SourceRecord = {
+  text: string
+  locator: string
+}


### PR DESCRIPTION
## Summary

- Adds a generic `Source` interface so persona loading can be backed by any storage — filesystem today, DB or HTTP tomorrow.
- Ships three reference implementations: `InMemorySource` (tests + bake-in seed templates), `FlatFileSource` (current filesystem layout), `LayeredSource` (first-wins read + union-dedupe list — the seed-then-emerge primitive).
- Refactors `loadPersona`/`listPersonas` to compose two `FlatFileSource`s through a `LayeredSource` internally; existing callers see no behavior change.

This is the `tnezdev/spores` half of the loader work named in the W18 overlay of [`DESIGN-runtime-description.md`](https://github.com/tnezdev/spores/tree/main/PROJECTS/spores/DESIGN-runtime-description.md). Compass can now build its own `DbSource` + seed-then-emerge `LayeredSource` against the same contract without waiting on a daemon-side migration. Skills, workflows, and the routing-hint frontmatter shape are intentionally out of scope — follow-up PRs, one primitive at a time.

### Public API additions

- `Source`, `SourceRecord` types
- `InMemorySource`, `FlatFileSource`, `LayeredSource` implementations
- `loadPersonaFromSource(name, source)`, `listPersonasFromSource(source)`

### Backward compatibility

- `loadPersona(name, baseDir)` and `listPersonas(baseDir)` signatures unchanged; they delegate to `LayeredSource([projectFlatFileSource, globalFlatFileSource])` internally.
- `FilesystemPersonaAdapter` unchanged.
- All 273 existing tests pass; +28 new tests.

### Design notes

- `read` returns `{ text, locator }` rather than just text — `locator` is a source-specific diagnostic identifier (filesystem path, in-memory tag, future URL). This keeps `PersonaFile.path` populated regardless of source without forcing every implementation to fake a path.
- `LayeredSource.list()` unions across all layers and dedupes by name. Live state shadows seed on `read` but both appear in `list` so consumers see the full catalog.
- `Source` is read-only by design. Mutation lives elsewhere (memory writes, direct source-implementation methods); this interface stays simple.
- Skills can't reuse `FlatFileSource` (they use `<dir>/<name>/skill.md`, not `<dir>/<name>.md`). When skills migrate, they'll get their own `NestedFileSource` or equivalent.

## Test plan

- [x] `bun test` — all 301 tests pass
- [x] `bun run typecheck` — clean
- [x] `bun src/cli/main.ts persona list` — works
- [x] `bun src/cli/main.ts persona view spores-maintainer` — works