### PR TITLE
feat: routing-hint frontmatter on personas (effort, reasoning)

### DIFF
--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -365,6 +365,8 @@ function formatMeta(ref: PersonaRef): string {
   if (ref.task_filter !== undefined)
     lines.push(`task_filter: ${JSON.stringify(ref.task_filter)}`)
   if (ref.workflow !== undefined) lines.push(`workflow: ${ref.workflow}`)
+  if (ref.effort !== undefined) lines.push(`effort: ${ref.effort}`)
+  if (ref.reasoning !== undefined) lines.push(`reasoning: ${ref.reasoning}`)
   return lines.join("\n")
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ export type {
   PersonaRef,
   PersonaFile,
   Persona,
+  RoutingHint,
   SituationalContext,
   HookInvocation,
   WorkflowRunStartedOutput,

--- a/src/personas/filesystem.test.ts
+++ b/src/personas/filesystem.test.ts
@@ -348,6 +348,54 @@ describe("loadPersonaFromSource", () => {
   })
 })
 
+describe("routing hints", () => {
+  test("parses effort and reasoning when both present and valid", async () => {
+    const source = new InMemorySource({
+      hinted: `---\nname: hinted\ndescription: with hints\neffort: high\nreasoning: medium\n---\nbody\n`,
+    })
+    const file = await loadPersonaFromSource("hinted", source)
+    expect(file!.effort).toBe("high")
+    expect(file!.reasoning).toBe("medium")
+  })
+
+  test("hints default to undefined when frontmatter omits them", async () => {
+    const source = new InMemorySource({ minimal: MINIMAL })
+    const file = await loadPersonaFromSource("minimal", source)
+    expect(file!.effort).toBeUndefined()
+    expect(file!.reasoning).toBeUndefined()
+  })
+
+  test("invalid hint values are dropped, persona still loads", async () => {
+    const source = new InMemorySource({
+      bad: `---\nname: bad\ndescription: bad hints\neffort: insane\nreasoning: galaxy-brain\n---\nbody\n`,
+    })
+    const file = await loadPersonaFromSource("bad", source)
+    expect(file).toBeDefined()
+    expect(file!.effort).toBeUndefined()
+    expect(file!.reasoning).toBeUndefined()
+  })
+
+  test("accepts each valid hint level", async () => {
+    for (const level of ["low", "medium", "high"]) {
+      const source = new InMemorySource({
+        p: `---\nname: p\ndescription: d\neffort: ${level}\nreasoning: ${level}\n---\n`,
+      })
+      const file = await loadPersonaFromSource("p", source)
+      expect(file!.effort).toBe(level as "low" | "medium" | "high")
+      expect(file!.reasoning).toBe(level as "low" | "medium" | "high")
+    }
+  })
+
+  test("listPersonasFromSource surfaces hints in refs", async () => {
+    const source = new InMemorySource({
+      hinted: `---\nname: hinted\ndescription: d\neffort: low\nreasoning: high\n---\n`,
+    })
+    const refs = await listPersonasFromSource(source)
+    expect(refs[0]!.effort).toBe("low")
+    expect(refs[0]!.reasoning).toBe("high")
+  })
+})
+
 describe("listPersonasFromSource", () => {
   test("lists personas from any source", async () => {
     const source = new InMemorySource({

--- a/src/personas/filesystem.ts
+++ b/src/personas/filesystem.ts
@@ -1,6 +1,12 @@
 import { join } from "node:path"
 import { homedir } from "node:os"
-import type { PersonaFile, PersonaRef, TaskQuery, TaskStatus } from "../types.js"
+import type {
+  PersonaFile,
+  PersonaRef,
+  RoutingHint,
+  TaskQuery,
+  TaskStatus,
+} from "../types.js"
 import type { Source } from "../sources/source.js"
 import { FlatFileSource } from "../sources/flat-file.js"
 import { LayeredSource } from "../sources/layered.js"
@@ -35,6 +41,8 @@ type ParsedMeta = {
   skills?: string[]
   task_filter?: TaskQuery
   workflow?: string
+  effort?: RoutingHint
+  reasoning?: RoutingHint
 }
 
 const TASK_STATUSES: readonly TaskStatus[] = [
@@ -47,6 +55,12 @@ const TASK_STATUSES: readonly TaskStatus[] = [
 
 function isTaskStatus(s: string): s is TaskStatus {
   return (TASK_STATUSES as readonly string[]).includes(s)
+}
+
+const ROUTING_HINTS: readonly RoutingHint[] = ["low", "medium", "high"]
+
+function isRoutingHint(s: string): s is RoutingHint {
+  return (ROUTING_HINTS as readonly string[]).includes(s)
 }
 
 function parseArray(rest: string): string[] {
@@ -120,6 +134,8 @@ function parseFrontmatter(text: string): { meta: ParsedMeta; body: string } {
     if (key === "name") meta.name = value
     else if (key === "description") meta.description = value
     else if (key === "workflow") meta.workflow = value
+    else if (key === "effort" && isRoutingHint(value)) meta.effort = value
+    else if (key === "reasoning" && isRoutingHint(value)) meta.reasoning = value
   }
 
   if (Object.keys(taskFilter).length > 0) {
@@ -138,6 +154,8 @@ function metaToRef(meta: ParsedMeta): PersonaRef | undefined {
     skills: meta.skills ?? [],
     task_filter: meta.task_filter,
     workflow: meta.workflow,
+    effort: meta.effort,
+    reasoning: meta.reasoning,
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -200,12 +200,26 @@ export type SituationalContext = {
 }
 
 /**
+ * Routing hint — advisory shape used by callers (run orchestrators) to map
+ * a persona to an LLM model and provider. Spores never binds a persona to
+ * a model directly; the routing layer owns that decision plus guardrails,
+ * observability, and provider fallback. Three levels are enough vocabulary
+ * to start; expand only when a real workload demands it.
+ */
+export type RoutingHint = "low" | "medium" | "high"
+
+/**
  * Metadata-only persona reference — cheap to list. Frontmatter fields only,
  * no body content. Used by `listPersonas()` and by callers scanning the
  * persona catalog for activation targets.
  *
  * Descriptions should be phrased as activation triggers ("Activate when...")
  * rather than labels ("The X maintainer") — they're agent-facing lookup hooks.
+ *
+ * `effort` and `reasoning` are advisory hints — see `RoutingHint`. The
+ * persona declares what it wants; the routing layer decides what model
+ * gets it. Personas never name models directly: a persona can edit itself,
+ * so capability-shaping fields belong outside the editable surface.
  */
 export type PersonaRef = {
   name: string
@@ -214,6 +228,8 @@ export type PersonaRef = {
   skills: string[]
   task_filter?: TaskQuery | undefined
   workflow?: string | undefined
+  effort?: RoutingHint | undefined
+  reasoning?: RoutingHint | undefined
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds two optional frontmatter fields to personas: `effort` and `reasoning`, each `"low" | "medium" | "high"`.
- Personas express what they want from the model; the routing layer (caller) decides which model gets it. Spores never binds a persona to a model directly.
- Closes out the routing-hint half of the W18 overlay's "smallest first move" pairing — the loader half landed in #37.

## Why hints, not model names

A persona can edit itself in SPORES land. Capability-shaping fields belong outside the editable surface — at the routing/orchestrator layer that the persona cannot rewrite. So we ship advisory hints that the routing layer maps to model + provider, plus its own guardrails, observability, and fallback. See [`DESIGN-runtime-description.md`](https://github.com/tnezdev/spores/tree/main/PROJECTS/spores/DESIGN-runtime-description.md) W18 overlay §2 + W18-later §"persona self-editability".

## Validation behavior

Invalid hint values (e.g. `effort: insane`) are dropped silently and the persona still loads — matches the precedent set by `task_filter.status`. The persona doesn't break; the field just stays undefined.

## Public API additions

- `RoutingHint` type
- `PersonaRef` gains optional `effort` and `reasoning` fields
- CLI `persona view` surfaces both in metadata output

## Test plan

- [x] `bun test` — 306 tests pass (+5 new)
- [x] `bun run typecheck` — clean
- [x] Manual: persona file with `effort: high\nreasoning: medium` round-trips through `persona view`