### PR TITLE
feat: Dispatch foundation types + pure match function

### DIFF
--- a/src/dispatch/match.test.ts
+++ b/src/dispatch/match.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test"
+import type { Dispatch, DispatchFilter } from "../types.js"
+import { match } from "./match.js"
+
+function makeDispatch(overrides: Partial<Dispatch> = {}): Dispatch {
+  return {
+    id: "01KNRZBRK1S3WAB2DTYG1TNTB5",
+    from: "pa:user-x",
+    to: "org:channel-y",
+    payload: { kind: "test" },
+    timestamp: "2026-04-27T12:00:00.000Z",
+    ...overrides,
+  }
+}
+
+describe("match", () => {
+  test("empty filter matches every dispatch", () => {
+    expect(match(makeDispatch(), {})).toBe(true)
+  })
+
+  test("from: exact string matches when equal", () => {
+    expect(match(makeDispatch({ from: "scheduler" }), { from: "scheduler" })).toBe(true)
+  })
+
+  test("from: exact string fails when unequal", () => {
+    expect(match(makeDispatch({ from: "pa:alice" }), { from: "scheduler" })).toBe(false)
+  })
+
+  test("from: array matches when value is in the list", () => {
+    const d = makeDispatch({ from: "surface:slack" })
+    expect(match(d, { from: ["surface:slack", "surface:email"] })).toBe(true)
+  })
+
+  test("from: array fails when value is not in the list", () => {
+    const d = makeDispatch({ from: "scheduler" })
+    expect(match(d, { from: ["surface:slack", "surface:email"] })).toBe(false)
+  })
+
+  test("to: exact string matches when equal", () => {
+    expect(match(makeDispatch({ to: "self" }), { to: "self" })).toBe(true)
+  })
+
+  test("to: array matches by inclusion", () => {
+    expect(
+      match(makeDispatch({ to: "pa:bob" }), { to: ["pa:alice", "pa:bob"] }),
+    ).toBe(true)
+  })
+
+  test("from + to: both must match (AND semantics)", () => {
+    const d = makeDispatch({ from: "scheduler", to: "self" })
+    expect(match(d, { from: "scheduler", to: "self" })).toBe(true)
+    expect(match(d, { from: "scheduler", to: "other" })).toBe(false)
+    expect(match(d, { from: "other", to: "self" })).toBe(false)
+  })
+
+  test("payload is not consulted by the foundation match function", () => {
+    // Any payload satisfies a filter that only constrains from/to.
+    const d = makeDispatch({ payload: { whatever: 42 } })
+    expect(match(d, { from: d.from })).toBe(true)
+  })
+
+  test("array filter with single element behaves like exact match", () => {
+    const filter: DispatchFilter = { from: ["only-this"] }
+    expect(match(makeDispatch({ from: "only-this" }), filter)).toBe(true)
+    expect(match(makeDispatch({ from: "anything-else" }), filter)).toBe(false)
+  })
+
+  test("empty array filter matches nothing", () => {
+    // An empty allowlist is "no values are acceptable" — different from
+    // the undefined case (no constraint).
+    const filter: DispatchFilter = { from: [] }
+    expect(match(makeDispatch(), filter)).toBe(false)
+  })
+})

--- a/src/dispatch/match.ts
+++ b/src/dispatch/match.ts
@@ -1,0 +1,30 @@
+import type { Dispatch, DispatchFilter } from "../types.js"
+
+/**
+ * Test whether a dispatch satisfies a declarative filter.
+ *
+ * A field constraint passes when:
+ *   - the filter omits it (no constraint), OR
+ *   - the filter is a string and equals the dispatch field, OR
+ *   - the filter is an array and includes the dispatch field.
+ *
+ * The empty filter `{}` matches every dispatch — useful as a catch-all
+ * (e.g. a debug logger handler).
+ *
+ * Pure: no runtime state, no side effects. Compose with predicate
+ * functions outside this module if you need richer matching.
+ */
+export function match(dispatch: Dispatch, filter: DispatchFilter): boolean {
+  if (!matchValue(dispatch.from, filter.from)) return false
+  if (!matchValue(dispatch.to, filter.to)) return false
+  return true
+}
+
+function matchValue(
+  value: string,
+  pattern: string | readonly string[] | undefined,
+): boolean {
+  if (pattern === undefined) return true
+  if (typeof pattern === "string") return value === pattern
+  return pattern.includes(value)
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,10 @@ export type {
   PersonaFile,
   Persona,
   SituationalContext,
+  DispatchId,
+  Dispatch,
+  DispatchFilter,
+  DispatchHandlerHooks,
   HookInvocation,
   WorkflowRunStartedOutput,
   WorkflowRunTerminatedOutput,
@@ -67,5 +71,7 @@ export type { Source, SourceRecord } from "./sources/source.js"
 export { InMemorySource } from "./sources/in-memory.js"
 export { FlatFileSource } from "./sources/flat-file.js"
 export { LayeredSource } from "./sources/layered.js"
+
+export { match as matchDispatch } from "./dispatch/match.js"
 
 export { fireHook } from "./hooks/fire.js"

--- a/src/types.ts
+++ b/src/types.ts
@@ -237,6 +237,75 @@ export type Persona = PersonaRef & {
 }
 
 // ---------------------------------------------------------------------------
+// Dispatch types
+//
+// A Dispatch is a message that crosses a boundary into an agent's turn:
+// from another agent (PA→ORG, ORG→PA), from a surface (Slack, email),
+// from a scheduler (recurring or one-shot wakes), or addressed to self.
+// Spores ships the message shape and pure match logic; the runtime
+// (caller) ships transport, scheduling, and handler execution.
+//
+// See PROJECTS/spores/DESIGN-runtime-description.md §"Dispatch primitive
+// shape" for the full design.
+// ---------------------------------------------------------------------------
+
+/** ULID-shaped identifier. Same monotonic-factory shape as Task.id. */
+export type DispatchId = string
+
+/**
+ * The message shape that crosses every boundary into an agent's turn.
+ * `from` and `to` are runtime-assigned addresses (e.g. `pa:user-x`,
+ * `org:channel-y`, `scheduler`, `self`, `surface:slack`); the convention
+ * is colon-separated kind:identifier but spores does not enforce it —
+ * callers can use whatever address scheme their runtime prefers.
+ *
+ * `when` and `recurrence` are *delivery metadata* — sender-side scheduling.
+ * The scheduler is just the runtime executor of recurring sends; from the
+ * handler's perspective, every dispatch arrives the same way regardless
+ * of source (scheduled, surface, agent-to-agent).
+ */
+export type Dispatch = {
+  id: DispatchId
+  from: string
+  to: string
+  payload: unknown
+  timestamp: string // ISO 8601 — when the dispatch was emitted
+  when?: string | undefined // ISO 8601 — deferred delivery
+  recurrence?: string | undefined // cron expression or ISO 8601 duration
+}
+
+/**
+ * Declarative predicate over `from` and `to`. A string matches by equality;
+ * a string array matches by inclusion (one-of). An undefined field places
+ * no constraint. An empty filter matches every dispatch.
+ *
+ * Payload-shape matching is intentionally absent at the foundation layer:
+ * payload schemas are source-specific, and a one-size predicate language
+ * would force premature decisions. Callers needing payload matching can
+ * compose a function filter `(d) => match(d, baseFilter) && payloadCheck(d)`
+ * outside this module.
+ */
+export type DispatchFilter = {
+  from?: string | readonly string[] | undefined
+  to?: string | readonly string[] | undefined
+}
+
+/**
+ * Lifecycle hooks attached at handler registration. `onRegister` runs once
+ * when the handler is brought up (idempotency is the registrar's
+ * responsibility — spores stays stateless about prior runs). `onUnregister`
+ * runs once at teardown. Both default to no-op when omitted.
+ *
+ * The caller (runtime) decides *when* to fire `onRegister` — at process
+ * boot for long-running daemons, at deploy time for serverless. Spores
+ * ships the hook shape; the runtime owns the policy.
+ */
+export type DispatchHandlerHooks = {
+  onRegister?: () => Promise<void>
+  onUnregister?: () => Promise<void>
+}
+
+// ---------------------------------------------------------------------------
 // Hook types
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Adds the foundation layer of the Dispatch primitive — the universal inbound shape for messages crossing into an agent's turn (PA↔ORG, surface→agent, scheduler→self).
- Spores ships the message shape and pure match logic; runtimes ship transport, scheduling, and handler execution. This split was named in the W18-later overlay of [`DESIGN-runtime-description.md`](https://github.com/tnezdev/spores/tree/main/PROJECTS/spores/DESIGN-runtime-description.md).
- Intentionally minimal: the full primitive (send/handle/cancel verbs, ID generation, registry helpers, file-config loader for declared recurring sends) lands when Beacon gives real friction signal.

## Public API additions

- `DispatchId`, `Dispatch`, `DispatchFilter`, `DispatchHandlerHooks` types
- `matchDispatch(dispatch, filter)` — pure predicate function

## Filter semantics

- `undefined` field = no constraint
- `string` = exact match
- `string[]` = one-of (inclusion)
- `[]` = match nothing (an empty allowlist is "no values acceptable")
- `from` and `to` together = AND
- Empty filter `{}` matches every dispatch (catch-all)

Payload-shape matching is intentionally absent. Payload schemas are source-specific; a one-size predicate language would force premature decisions. Callers compose function filters externally:

```ts
const handlerMatches = (d) => matchDispatch(d, baseFilter) && payloadCheck(d)
```

## Why this shape

Five use-cases on the Compass napkin (PA→ORG, ORG→PA, PA inbound, ORG inbound, scheduled wake) collapse to **two stances + one shape**:

- Outbound: send (caller territory)
- Inbound: handler registration with declarative filter (this PR ships the filter)
- Shape: `{ id, from, to, payload, timestamp, when?, recurrence? }`

Schedule isn't a separate primitive — it's a *source* of dispatches. Scheduler-emitted wakes arrive in the handler machinery indistinguishable from any other inbound dispatch.

## What's deliberately out

- ULID generation for `DispatchId` (generation lives at `dispatch.send` time; spores doesn't ship `send` yet)
- File-config loader for declared recurring sends (waits on real consumer friction)
- Handler registry / lifecycle execution (runtime concern)
- `Dispatch.bind(from)` factory (runtime convenience; spores stays neutral on identity)

These accrete only when a concrete consumer demands them.

## Test plan

- [x] `bun test` — 312 tests pass (+11 new)
- [x] `bun run typecheck` — clean