### PR TITLE
feat: source-pluggable loaders for skills and workflows

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,11 @@ export type { MemoryAdapter, AdapterCapabilities } from "./memory/adapter.js"
 export { FilesystemAdapter } from "./memory/filesystem.js"
 
 export type { WorkflowAdapter } from "./workflow/adapter.js"
-export { FilesystemWorkflowAdapter } from "./workflow/filesystem.js"
+export {
+  FilesystemWorkflowAdapter,
+  listGraphsFromSource,
+  loadGraphFromSource,
+} from "./workflow/filesystem.js"
 export { Runtime } from "./workflow/runtime.js"
 export {
   expandGraph,
@@ -52,7 +56,12 @@ export {
 
 export { loadConfig } from "./config.js"
 
-export { listSkills, loadSkill } from "./skills/filesystem.js"
+export {
+  listSkills,
+  listSkillsFromSource,
+  loadSkill,
+  loadSkillFromSource,
+} from "./skills/filesystem.js"
 
 export type { TaskAdapter } from "./tasks/adapter.js"
 export { FilesystemTaskAdapter } from "./tasks/filesystem.js"
@@ -71,6 +80,7 @@ export { resolveSituational } from "./personas/situational.js"
 export type { Source, SourceRecord } from "./sources/source.js"
 export { InMemorySource } from "./sources/in-memory.js"
 export { FlatFileSource } from "./sources/flat-file.js"
+export { NestedFileSource } from "./sources/nested-file.js"
 export { LayeredSource } from "./sources/layered.js"
 
 export { match as matchDispatch } from "./dispatch/match.js"

--- a/src/skills/filesystem.test.ts
+++ b/src/skills/filesystem.test.ts
@@ -2,7 +2,14 @@ import { describe, it, expect, beforeEach, afterEach } from "bun:test"
 import { mkdtemp, rm, mkdir, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
-import { listSkills, loadSkill } from "./filesystem.js"
+import { InMemorySource } from "../sources/in-memory.js"
+import { LayeredSource } from "../sources/layered.js"
+import {
+  listSkills,
+  listSkillsFromSource,
+  loadSkill,
+  loadSkillFromSource,
+} from "./filesystem.js"
 
 async function writeSkill(
   dir: string,
@@ -33,13 +40,20 @@ Minimal body.
 
 describe("skills/filesystem", () => {
   let tmpDir: string
+  let fakeHome: string
+  const originalHome = process.env["HOME"]
 
   beforeEach(async () => {
     tmpDir = await mkdtemp(join(tmpdir(), "spores-skills-test-"))
+    fakeHome = await mkdtemp(join(tmpdir(), "spores-skills-home-"))
+    process.env["HOME"] = fakeHome
   })
 
   afterEach(async () => {
+    if (originalHome !== undefined) process.env["HOME"] = originalHome
+    else delete process.env["HOME"]
     await rm(tmpDir, { recursive: true })
+    await rm(fakeHome, { recursive: true })
   })
 
   describe("listSkills", () => {
@@ -116,6 +130,95 @@ Body.
       await writeSkill(tmpDir, "broken", noDesc)
       const skill = await loadSkill("broken", tmpDir)
       expect(skill).toBeUndefined()
+    })
+
+    it("project skill wins over global on name conflict", async () => {
+      // Write to the fake-home global skills dir
+      const globalDir = join(fakeHome, ".spores", "skills", "dup")
+      await mkdir(globalDir, { recursive: true })
+      await writeFile(
+        join(globalDir, "skill.md"),
+        `---\nname: dup\ndescription: Global\n---\nglobal body\n`,
+      )
+      await writeSkill(
+        tmpDir,
+        "dup",
+        `---\nname: dup\ndescription: Project\n---\nproject body\n`,
+      )
+      const skill = await loadSkill("dup", tmpDir)
+      expect(skill!.description).toBe("Project")
+      expect(skill!.content.trim()).toBe("project body")
+    })
+
+    it("falls back to global skill when project version is absent", async () => {
+      const globalDir = join(fakeHome, ".spores", "skills", "global-only")
+      await mkdir(globalDir, { recursive: true })
+      await writeFile(
+        join(globalDir, "skill.md"),
+        `---\nname: global-only\ndescription: Global\n---\nglobal body\n`,
+      )
+      const skill = await loadSkill("global-only", tmpDir)
+      expect(skill!.description).toBe("Global")
+    })
+  })
+
+  describe("loadSkillFromSource", () => {
+    it("loads a skill from any source — no filesystem coupling", async () => {
+      const source = new InMemorySource(
+        { "my-skill": VALID_SKILL },
+        "test",
+      )
+      const skill = await loadSkillFromSource("my-skill", source)
+      expect(skill!.name).toBe("my-skill")
+      expect(skill!.description).toBe("Does something useful")
+      expect(skill!.tags).toEqual(["ai", "memory"])
+      expect(skill!.content.trim()).toBe("Body content here.")
+      expect(skill!.path).toBe("test:my-skill")
+    })
+
+    it("returns undefined when source has no record by that name", async () => {
+      const source = new InMemorySource({})
+      const skill = await loadSkillFromSource("missing", source)
+      expect(skill).toBeUndefined()
+    })
+
+    it("layered source: live state shadows seed", async () => {
+      const seed = new InMemorySource(
+        {
+          "my-skill": `---\nname: my-skill\ndescription: Seed version\n---\nseed body\n`,
+        },
+        "seed",
+      )
+      const live = new InMemorySource(
+        {
+          "my-skill": `---\nname: my-skill\ndescription: Live version\n---\nlive body\n`,
+        },
+        "live",
+      )
+      const layered = new LayeredSource([live, seed])
+      const skill = await loadSkillFromSource("my-skill", layered)
+      expect(skill!.description).toBe("Live version")
+      expect(skill!.content.trim()).toBe("live body")
+    })
+  })
+
+  describe("listSkillsFromSource", () => {
+    it("lists skills from any source", async () => {
+      const source = new InMemorySource({
+        alpha: `---\nname: alpha\ndescription: A\n---\n`,
+        zebra: `---\nname: zebra\ndescription: Z\n---\n`,
+      })
+      const refs = await listSkillsFromSource(source)
+      expect(refs.map((r) => r.name)).toEqual(["alpha", "zebra"])
+    })
+
+    it("skips records with missing required fields", async () => {
+      const source = new InMemorySource({
+        ok: `---\nname: ok\ndescription: ok\n---\n`,
+        broken: `---\nname: broken\n---\n`,
+      })
+      const refs = await listSkillsFromSource(source)
+      expect(refs.map((r) => r.name)).toEqual(["ok"])
     })
   })
 })

--- a/src/skills/filesystem.ts
+++ b/src/skills/filesystem.ts
@@ -1,15 +1,9 @@
-import { readdir, readFile } from "node:fs/promises"
-import { join } from "node:path"
 import { homedir } from "node:os"
+import { join } from "node:path"
 import type { Skill, SkillRef } from "../types.js"
-
-interface NodeError extends Error {
-  code?: string | undefined
-}
-
-function isNodeError(err: unknown): err is NodeError {
-  return err instanceof Error
-}
+import type { Source } from "../sources/source.js"
+import { LayeredSource } from "../sources/layered.js"
+import { NestedFileSource } from "../sources/nested-file.js"
 
 // ---------------------------------------------------------------------------
 // Frontmatter parser
@@ -67,55 +61,86 @@ function parseFrontmatter(text: string): { meta: Frontmatter; body: string } {
   return { meta, body }
 }
 
-// ---------------------------------------------------------------------------
-// Directory scanning
-// ---------------------------------------------------------------------------
-
-async function scanSkillsDir(dir: string): Promise<SkillRef[]> {
-  let entries: string[]
-  try {
-    entries = await readdir(dir)
-  } catch (err) {
-    if (isNodeError(err) && err.code === "ENOENT") return []
-    throw err
+function metaToRef(meta: Frontmatter, locator: string): SkillRef | undefined {
+  if (meta.name === undefined || meta.description === undefined) return undefined
+  return {
+    name: meta.name,
+    description: meta.description,
+    tags: meta.tags ?? [],
+    path: locator,
   }
-
-  const refs: SkillRef[] = []
-
-  for (const entry of entries) {
-    const skillFile = join(dir, entry, "skill.md")
-    let text: string
-    try {
-      text = await readFile(skillFile, "utf-8")
-    } catch (err) {
-      if (isNodeError(err) && err.code === "ENOENT") continue
-      throw err
-    }
-
-    const { meta } = parseFrontmatter(text)
-    if (meta.name === undefined || meta.description === undefined) continue
-
-    refs.push({
-      name: meta.name,
-      description: meta.description,
-      tags: meta.tags ?? [],
-      path: skillFile,
-    })
-  }
-
-  return refs
 }
 
 // ---------------------------------------------------------------------------
-// Public API
+// Source-based API — works with any pluggable Source
 // ---------------------------------------------------------------------------
 
+/**
+ * List all skills exposed by the given source. Skips records whose
+ * frontmatter is missing required fields (`name`, `description`) or
+ * whose entries don't resolve to a readable body — those are surfaced
+ * quietly rather than throwing, matching `loadSkill`'s "return undefined
+ * for malformed" semantics.
+ */
+export async function listSkillsFromSource(
+  source: Source,
+): Promise<SkillRef[]> {
+  const names = await source.list()
+  const refs: SkillRef[] = []
+
+  for (const name of names) {
+    const record = await source.read(name)
+    if (record === undefined) continue
+
+    const { meta } = parseFrontmatter(record.text)
+    const ref = metaToRef(meta, record.locator)
+    if (ref !== undefined) refs.push(ref)
+  }
+
+  return refs.sort((a, b) => a.name.localeCompare(b.name))
+}
+
+/**
+ * Load a single skill by name from a source. Returns undefined if the
+ * name is not found or the frontmatter is missing required fields.
+ */
+export async function loadSkillFromSource(
+  name: string,
+  source: Source,
+): Promise<Skill | undefined> {
+  const record = await source.read(name)
+  if (record === undefined) return undefined
+
+  const { meta, body } = parseFrontmatter(record.text)
+  const ref = metaToRef(meta, record.locator)
+  if (ref === undefined) return undefined
+
+  return { ...ref, content: body }
+}
+
+// ---------------------------------------------------------------------------
+// Convenience API — filesystem layering of project + global skills
+// ---------------------------------------------------------------------------
+
+function userHome(): string {
+  // Prefer HOME env var so tests can override it. Falls back to os.homedir()
+  // which reads the system password database on Unix.
+  return process.env["HOME"] ?? homedir()
+}
+
 function globalSkillsDir(): string {
-  return join(homedir(), ".spores", "skills")
+  return join(userHome(), ".spores", "skills")
 }
 
 function projectSkillsDir(baseDir: string): string {
   return join(baseDir, ".spores", "skills")
+}
+
+function defaultFilesystemSource(baseDir: string): Source {
+  return new LayeredSource([
+    new NestedFileSource(projectSkillsDir(baseDir), "skill.md"),
+    new NestedFileSource(globalSkillsDir(), "skill.md"),
+  ])
 }
 
 /**
@@ -123,19 +148,7 @@ function projectSkillsDir(baseDir: string): string {
  * global skills (`~/.spores/skills/`) when names conflict.
  */
 export async function listSkills(baseDir: string): Promise<SkillRef[]> {
-  const [global, project] = await Promise.all([
-    scanSkillsDir(globalSkillsDir()),
-    scanSkillsDir(projectSkillsDir(baseDir)),
-  ])
-
-  // Merge: project wins on name conflict
-  const byName = new Map<string, SkillRef>()
-  for (const ref of global) byName.set(ref.name, ref)
-  for (const ref of project) byName.set(ref.name, ref)
-
-  return Array.from(byName.values()).sort((a, b) =>
-    a.name.localeCompare(b.name),
-  )
+  return listSkillsFromSource(defaultFilesystemSource(baseDir))
 }
 
 /**
@@ -146,30 +159,5 @@ export async function loadSkill(
   name: string,
   baseDir: string,
 ): Promise<Skill | undefined> {
-  // Check project first, then global
-  const dirs = [projectSkillsDir(baseDir), globalSkillsDir()]
-
-  for (const dir of dirs) {
-    const skillFile = join(dir, name, "skill.md")
-    let text: string
-    try {
-      text = await readFile(skillFile, "utf-8")
-    } catch (err) {
-      if (isNodeError(err) && err.code === "ENOENT") continue
-      throw err
-    }
-
-    const { meta, body } = parseFrontmatter(text)
-    if (meta.name === undefined || meta.description === undefined) continue
-
-    return {
-      name: meta.name,
-      description: meta.description,
-      tags: meta.tags ?? [],
-      path: skillFile,
-      content: body,
-    }
-  }
-
-  return undefined
+  return loadSkillFromSource(name, defaultFilesystemSource(baseDir))
 }

--- a/src/sources/nested-file.test.ts
+++ b/src/sources/nested-file.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { mkdir, mkdtemp, writeFile, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { NestedFileSource } from "./nested-file.js"
+
+let dir: string
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "spores-nested-"))
+})
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true })
+})
+
+describe("NestedFileSource", () => {
+  test("read returns text + absolute path locator", async () => {
+    await mkdir(join(dir, "alpha"), { recursive: true })
+    const file = join(dir, "alpha", "skill.md")
+    await writeFile(file, "alpha-body")
+    const source = new NestedFileSource(dir, "skill.md")
+    const record = await source.read("alpha")
+    expect(record).toEqual({ text: "alpha-body", locator: file })
+  })
+
+  test("read returns undefined when subdir lacks the inner file", async () => {
+    await mkdir(join(dir, "empty"), { recursive: true })
+    const source = new NestedFileSource(dir, "skill.md")
+    const record = await source.read("empty")
+    expect(record).toBeUndefined()
+  })
+
+  test("read returns undefined when subdir does not exist", async () => {
+    const source = new NestedFileSource(dir, "skill.md")
+    const record = await source.read("missing")
+    expect(record).toBeUndefined()
+  })
+
+  test("read returns undefined when parent directory does not exist", async () => {
+    const source = new NestedFileSource(join(dir, "nonexistent"), "skill.md")
+    const record = await source.read("anything")
+    expect(record).toBeUndefined()
+  })
+
+  test("list returns subdirectory names, sorted", async () => {
+    await mkdir(join(dir, "zebra"), { recursive: true })
+    await mkdir(join(dir, "alpha"), { recursive: true })
+    await mkdir(join(dir, "mike"), { recursive: true })
+    const source = new NestedFileSource(dir, "skill.md")
+    expect(await source.list()).toEqual(["alpha", "mike", "zebra"])
+  })
+
+  test("list ignores top-level files (only subdirectories surface)", async () => {
+    await mkdir(join(dir, "alpha"), { recursive: true })
+    await writeFile(join(dir, "README.md"), "not a skill")
+    const source = new NestedFileSource(dir, "skill.md")
+    expect(await source.list()).toEqual(["alpha"])
+  })
+
+  test("list returns empty array when parent directory does not exist", async () => {
+    const source = new NestedFileSource(join(dir, "nonexistent"), "skill.md")
+    expect(await source.list()).toEqual([])
+  })
+
+  test("list does not verify the inner file exists (caller's read handles it)", async () => {
+    // A subdir without the expected inner file still appears in `list`;
+    // `read` returns undefined for it. This matches the "list is cheap,
+    // read is authoritative" contract.
+    await mkdir(join(dir, "valid"), { recursive: true })
+    await writeFile(join(dir, "valid", "skill.md"), "ok")
+    await mkdir(join(dir, "no-skill"), { recursive: true })
+    const source = new NestedFileSource(dir, "skill.md")
+    expect(await source.list()).toEqual(["no-skill", "valid"])
+    expect(await source.read("no-skill")).toBeUndefined()
+    expect(await source.read("valid")).toBeDefined()
+  })
+
+  test("custom inner filename works", async () => {
+    await mkdir(join(dir, "alpha"), { recursive: true })
+    await writeFile(join(dir, "alpha", "spec.json"), '{"id":"x"}')
+    const source = new NestedFileSource(dir, "spec.json")
+    const record = await source.read("alpha")
+    expect(record!.text).toBe('{"id":"x"}')
+  })
+})

--- a/src/sources/nested-file.ts
+++ b/src/sources/nested-file.ts
@@ -1,0 +1,56 @@
+import { readdir, readFile } from "node:fs/promises"
+import { join } from "node:path"
+import type { Source, SourceRecord } from "./source.js"
+
+interface NodeError extends Error {
+  code?: string | undefined
+}
+
+function isNodeError(err: unknown): err is NodeError {
+  return err instanceof Error
+}
+
+/**
+ * A `Source` backed by `<dir>/<name>/<filename>` — one subdirectory per
+ * record, with the body in a fixed file inside. Suits skills
+ * (`<dir>/<name>/skill.md`) and any future primitive that wants
+ * a directory per record (e.g. for co-located assets).
+ *
+ * `list()` returns subdirectory names without verifying the inner file
+ * exists — the caller's `read` handles the missing case via `undefined`.
+ * This keeps `list` cheap (one `readdir`, no extra stats).
+ *
+ * Missing parent directory is treated as empty.
+ */
+export class NestedFileSource implements Source {
+  constructor(
+    private readonly dir: string,
+    private readonly filename: string,
+  ) {}
+
+  async read(name: string): Promise<SourceRecord | undefined> {
+    const file = join(this.dir, name, this.filename)
+    try {
+      const text = await readFile(file, "utf-8")
+      return { text, locator: file }
+    } catch (err) {
+      if (isNodeError(err) && err.code === "ENOENT") return undefined
+      throw err
+    }
+  }
+
+  async list(): Promise<string[]> {
+    let entries: Array<{ name: string; isDirectory: () => boolean }>
+    try {
+      entries = await readdir(this.dir, { withFileTypes: true })
+    } catch (err) {
+      if (isNodeError(err) && err.code === "ENOENT") return []
+      throw err
+    }
+
+    return entries
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
+      .sort()
+  }
+}

--- a/src/workflow/filesystem.test.ts
+++ b/src/workflow/filesystem.test.ts
@@ -3,7 +3,13 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it } from "bun:test"
 import type { GraphDef, Transition } from "../types.js"
-import { FilesystemWorkflowAdapter } from "./filesystem.js"
+import { InMemorySource } from "../sources/in-memory.js"
+import { LayeredSource } from "../sources/layered.js"
+import {
+  FilesystemWorkflowAdapter,
+  listGraphsFromSource,
+  loadGraphFromSource,
+} from "./filesystem.js"
 
 function makeGraph(id = "g1"): GraphDef {
   return {
@@ -173,5 +179,73 @@ describe("FilesystemWorkflowAdapter", () => {
       expect(loaded!.history).toHaveLength(1)
       expect(loaded!.history[0]).toEqual(t)
     })
+  })
+})
+
+describe("loadGraphFromSource", () => {
+  it("loads a graph from any source — no filesystem coupling", async () => {
+    const graph = makeGraph()
+    const source = new InMemorySource({ g1: JSON.stringify(graph) }, "test")
+    const loaded = await loadGraphFromSource("g1", source)
+    expect(loaded).toEqual(graph)
+  })
+
+  it("returns undefined when source has no record by that id", async () => {
+    const source = new InMemorySource({})
+    const loaded = await loadGraphFromSource("missing", source)
+    expect(loaded).toBeUndefined()
+  })
+
+  it("layered source: live state shadows seed", async () => {
+    const seedGraph = { ...makeGraph(), name: "Seed" }
+    const liveGraph = { ...makeGraph(), name: "Live" }
+    const seed = new InMemorySource(
+      { g1: JSON.stringify(seedGraph) },
+      "seed",
+    )
+    const live = new InMemorySource(
+      { g1: JSON.stringify(liveGraph) },
+      "live",
+    )
+    const layered = new LayeredSource([live, seed])
+    const loaded = await loadGraphFromSource("g1", layered)
+    expect(loaded!.name).toBe("Live")
+  })
+
+  it("throws on malformed JSON", async () => {
+    const source = new InMemorySource({ g1: "not valid json" })
+    expect(loadGraphFromSource("g1", source)).rejects.toThrow()
+  })
+})
+
+describe("listGraphsFromSource", () => {
+  it("lists all compiled graphs from a source", async () => {
+    const a = { ...makeGraph("a"), name: "Alpha" }
+    const b = { ...makeGraph("b"), name: "Beta" }
+    const source = new InMemorySource({
+      a: JSON.stringify(a),
+      b: JSON.stringify(b),
+    })
+    const graphs = await listGraphsFromSource(source)
+    const names = graphs.map((g) => g.name).sort()
+    expect(names).toEqual(["Alpha", "Beta"])
+  })
+
+  it("skips records whose names end in .source", async () => {
+    const compiled = makeGraph("g1")
+    const sourceForm = { ...makeGraph("g1"), name: "un-expanded" }
+    const source = new InMemorySource({
+      g1: JSON.stringify(compiled),
+      "g1.source": JSON.stringify(sourceForm),
+    })
+    const graphs = await listGraphsFromSource(source)
+    expect(graphs).toHaveLength(1)
+    expect(graphs[0]!.id).toBe("g1")
+    expect(graphs[0]!.name).toBe("Test Graph")
+  })
+
+  it("returns empty array from empty source", async () => {
+    const graphs = await listGraphsFromSource(new InMemorySource({}))
+    expect(graphs).toEqual([])
   })
 })

--- a/src/workflow/filesystem.ts
+++ b/src/workflow/filesystem.ts
@@ -2,6 +2,7 @@ import { mkdir, readdir, readFile, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { randomUUID } from "node:crypto"
 import type { GraphDef, Run, Transition } from "../types.js"
+import type { Source } from "../sources/source.js"
 import type { WorkflowAdapter } from "./adapter.js"
 
 interface NodeError extends Error {
@@ -137,4 +138,57 @@ export class FilesystemWorkflowAdapter implements WorkflowAdapter {
     run.history.push(transition)
     await writeFile(filePath, JSON.stringify(run, null, 2))
   }
+}
+
+// ---------------------------------------------------------------------------
+// Source-based graph loading
+//
+// Compass + remote runtimes load `GraphDef`s from non-filesystem sources
+// (DB, layered seed-then-emerge). The Source abstraction handles the read
+// path; run state stays on the adapter (it's runtime data, not config).
+//
+// Source records carrying names ending in `.source` are skipped — those
+// are the un-expanded source graphs the adapter writes alongside compiled
+// graphs. Same exclusion the filesystem `listGraphs` enforces.
+// ---------------------------------------------------------------------------
+
+const SOURCE_GRAPH_SUFFIX = ".source"
+
+/**
+ * Load a graph definition by ID from any source. Source records are raw
+ * JSON text; this parses them into `GraphDef`. Returns undefined when the
+ * source has no record by that ID.
+ *
+ * Throws on JSON parse error — a malformed graph is a real bug, not a
+ * "not found" case.
+ */
+export async function loadGraphFromSource(
+  graphId: string,
+  source: Source,
+): Promise<GraphDef | undefined> {
+  const record = await source.read(graphId)
+  if (record === undefined) return undefined
+  return JSON.parse(record.text) as GraphDef
+}
+
+/**
+ * List all compiled graph definitions exposed by a source. Skips records
+ * whose names end in `.source` (those are un-expanded source graphs that
+ * pair with compiled graphs in the adapter's filesystem layout). Throws
+ * on JSON parse error.
+ */
+export async function listGraphsFromSource(
+  source: Source,
+): Promise<GraphDef[]> {
+  const names = await source.list()
+  const graphs: GraphDef[] = []
+
+  for (const name of names) {
+    if (name.endsWith(SOURCE_GRAPH_SUFFIX)) continue
+    const record = await source.read(name)
+    if (record === undefined) continue
+    graphs.push(JSON.parse(record.text) as GraphDef)
+  }
+
+  return graphs
 }


### PR DESCRIPTION
## Summary

- Brings skills and workflow graphs onto the same `Source` abstraction landed for personas in #37.
- Closes the loader-migration story for spores' file-style config primitives — Compass and other remote runtimes can now load **every** primitive (personas, skills, workflows) from a `DbSource` or layered seed-then-emerge source without hitting hardcoded filesystem paths.

## Why this batches with the previous loader work

Without skills + workflows, Compass's first refactor would hit a wall: "great, I can load personas from `DbSource`, but workflows still want a hardcoded `baseDir`." Shipping all three together gives a clean integration boundary.

## New source implementation

- `NestedFileSource(dir, filename)` — `<dir>/<name>/<filename>` layouts. Suits skills (`<dir>/<name>/skill.md`) and any future primitive that wants a directory per record (co-located assets, etc.).

## New per-primitive loaders

- `listSkillsFromSource` / `loadSkillFromSource`
- `listGraphsFromSource` / `loadGraphFromSource`

Existing convenience APIs (`listSkills`/`loadSkill`, `FilesystemWorkflowAdapter`) unchanged — they delegate through the new abstraction.

## Notable design choices

- **Workflow run state stays on `FilesystemWorkflowAdapter`.** `Source` is read-only by design, and run state is per-tenant *runtime data*, not config. That separation comes later if needed; for now graph loading and run state simply live in different shapes.
- **`.source.json` exclusion lives in the workflow loader, not the source.** Filtering by name suffix is a workflow-specific quirk (un-expanded source graphs); keeping it out of `FlatFileSource` preserves the source's general purpose.
- **Skills filesystem loader gains HOME-aware global dir resolution** to match personas. This unblocks a project-vs-global override test that was previously untestable. Small unrelated fix riding along because it's a single-line change with clear value.

## Public API additions

- `NestedFileSource` (new sources implementation)
- `listSkillsFromSource`, `loadSkillFromSource`
- `listGraphsFromSource`, `loadGraphFromSource`

## Test plan

- [x] `bun test` — 340 tests pass (+28 new)
- [x] `bun run typecheck` — clean
- [x] `spores skill list` — verified working
- [x] `spores workflow list` — verified working