### PR TITLE
chore: pre-release cleanup — wire routing hints end-to-end + refresh docs

### DIFF
--- a/.spores/personas/spores-maintainer.md
+++ b/.spores/personas/spores-maintainer.md
@@ -1,17 +1,19 @@
 ---
 name: spores-maintainer
 description: Activate when working on the @tnezdev/spores toolbelt — implementation, tests, release prep, or milestone planning
-memory_tags: [spores, npm-publishing, v0.1]
+memory_tags: [spores, npm-publishing]
 skills: [release-check]
 task_filter:
   tags: [spores]
   status: ready
 workflow: spores-release
+effort: high
+reasoning: high
 ---
 
 # Spores maintainer
 
-You are working on `@tnezdev/spores` — a TypeScript library + CLI on Bun that ships agent in-loop primitives (memory, workflow, skills, tasks, persona). Current milestone: **v0.1 — coherent primitives MVP**.
+You are working on `@tnezdev/spores` — a TypeScript library + CLI on Bun that ships agent in-loop primitives. Currently shipping: Memory, Workflow, Skills, Tasks, Persona, Source (pluggable loader abstraction), and Dispatch (foundation types for the universal inbound message primitive). Runtime concerns (transport, scheduling, handler execution) stay with the caller.
 
 You are on `{{hostname}}`, working from `{{cwd}}`, on branch `{{git_branch}}`.
 The time is `{{timestamp}}`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,13 +8,15 @@ This repo dogfoods its own toolbelt. Before touching code, run the three-command
 
 ## What is SPORES?
 
-A TypeScript library + CLI for agent in-loop primitives. Four things, focused by a fifth:
+A TypeScript library + CLI for agent in-loop primitives:
 
 1. **Memory** — remember/recall/dream with L1/L2/L3 tiers
 2. **Skills** — load and run skill.md files from `.spores/skills/`
 3. **Workflow** — digraph runtime (GraphDef → Run → Transitions, state derived from history)
 4. **Tasks** — typed adapter interface (ULID IDs, Taskwarrior-shaped)
-5. **Persona** — activate a hat at the start of a turn: metadata (memory_tags, skills, task_filter, workflow) + a rendered body with live situational facts. Declarative attention, not enforced scope.
+5. **Persona** — activate a hat at the start of a turn: metadata (memory_tags, skills, task_filter, workflow, routing hints) + a rendered body with live situational facts. Declarative attention, not enforced scope.
+6. **Source** — pluggable read-only loader abstraction (`read(name) → text`, `list() → names`). Personas/skills/workflows all load through the same shape. `LayeredSource` composes for seed-then-emerge (e.g. live DB shadows seed filesystem). See "Source abstraction" below.
+7. **Dispatch** — foundation types for the universal inbound message primitive (`Dispatch`, `DispatchFilter`, `matchDispatch`). Spores ships the message shape and pure match logic; runtimes ship transport, scheduling, and handler execution.
 
 MVP scope = what an agent reaches for *inside a single turn*. No hosting, no webhooks, no session layer — those are daemon-level concerns. **Identity lives outside spores** — in the run orchestration layer. Spores provides the hat; the caller provides who's wearing it.
 
@@ -40,7 +42,7 @@ All shared types live in `src/types.ts`. Add types there before writing implemen
 
 ### Adapter pattern
 
-Every primitive has an interface in `src/<module>/adapter.ts`. Filesystem implementations are the default (and currently only) adapters. Future storage backends implement the same interface.
+Every primitive has an interface in `src/<module>/adapter.ts`. Filesystem implementations are the default. Future storage backends implement the same interface.
 
 | Module | Interface | Implementation |
 |--------|-----------|----------------|
@@ -48,6 +50,28 @@ Every primitive has an interface in `src/<module>/adapter.ts`. Filesystem implem
 | workflow | `WorkflowAdapter` | `src/workflow/filesystem.ts` |
 | tasks | `TaskAdapter` | `src/tasks/adapter.ts` (stub only) |
 | personas | `PersonaAdapter` | `src/personas/filesystem.ts` |
+
+### Source abstraction
+
+Config-style primitives (personas, skills, workflows, file-style dispatch configs) load through a pluggable `Source` interface in `src/sources/`:
+
+```typescript
+interface Source {
+  read(name: string): Promise<SourceRecord | undefined>  // text + locator
+  list(): Promise<string[]>
+}
+```
+
+Reference implementations:
+
+- `FlatFileSource(dir, ext)` — `<dir>/<name><ext>` layouts (personas, workflows)
+- `NestedFileSource(dir, filename)` — `<dir>/<name>/<filename>` layouts (skills)
+- `InMemorySource(records, tag)` — for tests and bake-in seed templates
+- `LayeredSource([liveSource, seedSource])` — first-wins read, union-dedupe list (the seed-then-emerge primitive)
+
+Per-primitive load functions (`loadPersonaFromSource`, `loadSkillFromSource`, `loadGraphFromSource`) accept any `Source` — Compass and other remote runtimes plug in their own (DB, HTTP) without touching spores.
+
+Data primitives (Memory, Artifacts, Tasks) have query semantics and live behind their own adapter shapes — `Source` is for config, not data.
 
 ### CLI: two-word dispatch
 
@@ -99,6 +123,14 @@ Flat-file layout (unlike skills which use a directory per skill). Frontmatter: `
 - `expandGraph` flattens nested subgraphs at register time — nesting is free
 - `Runtime` is a **state machine only** — it derives current state from `Run.history` (no `current_node` field). It does NOT schedule or evaluate `EvaluatorRef` conditions — that's the caller's job.
 - State is immutable: each transition appends to `history`
+
+### Dispatch
+
+Foundation only — the message shape and pure match logic. `Dispatch` carries `from`, `to`, `payload`, `timestamp`, plus optional `when` / `recurrence` delivery metadata. `DispatchFilter` is a declarative predicate over `from` / `to`; `matchDispatch(dispatch, filter)` returns boolean. `DispatchHandlerHooks` types `onRegister` / `onUnregister` for handler-level lifecycle setup (idempotency lives in the hook, not in spores).
+
+Runtimes own send/handle/cancel verbs, the actual transport, scheduling, and handler execution. The split — vocabulary in spores, execution in runtime — keeps spores callable from both long-running daemons and serverless deployments.
+
+See `PROJECTS/spores/DESIGN-runtime-description.md` for the full design conversation.
 
 ### SporesUri
 

--- a/src/cli/commands/persona.ts
+++ b/src/cli/commands/persona.ts
@@ -49,6 +49,8 @@ export const personaActivateCommand: Command = async (ctx, args, _flags) => {
       SPORES_PERSONA_MEMORY_TAGS: persona.memory_tags.join(","),
       SPORES_PERSONA_SKILLS: persona.skills.join(","),
       SPORES_PERSONA_WORKFLOW: persona.workflow ?? "",
+      SPORES_PERSONA_EFFORT: persona.effort ?? "",
+      SPORES_PERSONA_REASONING: persona.reasoning ?? "",
     },
     ctx.baseDir,
   )

--- a/src/cli/main.test.ts
+++ b/src/cli/main.test.ts
@@ -551,6 +551,74 @@ The cwd is {{cwd}}.
       expect(result.hook.stdout).toContain("tags=spores,npm")
     })
 
+    it("activate exposes routing hints (effort, reasoning) as hook env vars", async () => {
+      const HINTED = `---
+name: hinted
+description: Activate to test hint propagation
+memory_tags: [test]
+effort: high
+reasoning: medium
+---
+
+Body.
+`
+      await writePersona(
+        join(tmpDir, ".spores", "personas"),
+        "hinted.md",
+        HINTED,
+      )
+      const hookDir = join(tmpDir, ".spores", "hooks")
+      await mkdir(hookDir, { recursive: true })
+      const hookPath = join(hookDir, "persona.activated")
+      await writeFile(
+        hookPath,
+        '#!/usr/bin/env bash\necho "effort=$SPORES_PERSONA_EFFORT"\necho "reasoning=$SPORES_PERSONA_REASONING"\n',
+      )
+      const { chmod } = await import("node:fs/promises")
+      await chmod(hookPath, 0o755)
+
+      const result = (await runPersonaJson(
+        ...base,
+        "persona",
+        "activate",
+        "hinted",
+      )) as {
+        hook: { stdout: string; exit_code: number | null }
+      }
+      expect(result.hook.stdout).toContain("effort=high")
+      expect(result.hook.stdout).toContain("reasoning=medium")
+    })
+
+    it("activate exposes empty hint env vars when persona omits them", async () => {
+      // Personas without effort/reasoning still get the env vars defined
+      // (as empty strings) so hook scripts can rely on them existing.
+      await writePersona(
+        join(tmpDir, ".spores", "personas"),
+        "spores-maintainer.md",
+        SAMPLE,
+      )
+      const hookDir = join(tmpDir, ".spores", "hooks")
+      await mkdir(hookDir, { recursive: true })
+      const hookPath = join(hookDir, "persona.activated")
+      await writeFile(
+        hookPath,
+        '#!/usr/bin/env bash\necho "effort=[$SPORES_PERSONA_EFFORT]"\necho "reasoning=[$SPORES_PERSONA_REASONING]"\n',
+      )
+      const { chmod } = await import("node:fs/promises")
+      await chmod(hookPath, 0o755)
+
+      const result = (await runPersonaJson(
+        ...base,
+        "persona",
+        "activate",
+        "spores-maintainer",
+      )) as {
+        hook: { stdout: string }
+      }
+      expect(result.hook.stdout).toContain("effort=[]")
+      expect(result.hook.stdout).toContain("reasoning=[]")
+    })
+
     it("view fails on missing persona", async () => {
       const { exitCode, stderr } = await runPersona(
         ...base,

--- a/src/personas/activate.ts
+++ b/src/personas/activate.ts
@@ -32,14 +32,11 @@ export function activatePersona(
     return match // unknown token — leave literal
   })
 
+  // Spread carries every PersonaRef field through; override `body` with the
+  // substituted version. Forward-compatible: new optional fields added to
+  // PersonaRef automatically propagate to the rendered Persona.
   return {
-    name: file.name,
-    description: file.description,
-    memory_tags: file.memory_tags,
-    skills: file.skills,
-    task_filter: file.task_filter,
-    workflow: file.workflow,
-    path: file.path,
+    ...file,
     body,
     situational,
   }


### PR DESCRIPTION
## Summary

Three loose ends to sweep before cutting v0.4.0. No new features — this is the housekeeping that should ride with the release so consumers find a clean surface.

### 1. Routing hints reach the `persona.activated` hook

#38 added `effort` and `reasoning` to `PersonaRef`, but the propagation chain was incomplete:

- `activatePersona()` dropped both fields on the way from `PersonaFile` → rendered `Persona`. Fixed by spreading `...file` instead of enumerating fields — forward-compatible for any future `PersonaRef` field.
- The `persona.activated` hook firing in `src/cli/commands/persona.ts` didn't expose the new fields as env vars. Added `SPORES_PERSONA_EFFORT` and `SPORES_PERSONA_REASONING` (empty string when omitted, matching the existing pattern for `SPORES_PERSONA_WORKFLOW`).

### 2. Dogfood the new fields

`.spores/personas/spores-maintainer.md`:
- Adopts `effort: high` / `reasoning: high` (the maintainer hat is exactly the profile those describe).
- Drops the stale `v0.1` memory tag — recall would surface dated context.
- Refreshes the milestone wording in the body to reflect the current primitive surface.

### 3. AGENTS.md catches up with the post-W18 primitive surface

- Lists Source and Dispatch as first-class primitives alongside the original five.
- New "Source abstraction" section walks the `Source` interface, the four reference implementations (`FlatFileSource`, `NestedFileSource`, `InMemorySource`, `LayeredSource`), and the data-vs-config boundary.
- New "Dispatch" section names the runtime-vs-spores split (vocabulary in spores, execution in runtime) so consumers don't expect a transport layer.

## Test plan

- [x] `bun test` — 342 pass
- [x] `bun run typecheck` — clean
- [x] Manual: `persona view spores-maintainer` shows `effort: high`, `reasoning: high` in metadata
- [x] New tests: hook env vars populated when persona has hints, empty strings when persona omits them