### PR TITLE
feat: tsc build pipeline for Node + Workers consumption (closes #32)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,16 @@ jobs:
 
       - name: Test
         run: bun test
+
+      - name: Build (tsc → dist/)
+        run: bun run build
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Smoke test (Bun consumer install from tarball)
+        run: bash scripts/smoke-test.sh
+
+      - name: Smoke test (Node consumer install from tarball)
+        run: bash scripts/smoke-test-node.sh

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,13 +31,19 @@ jobs:
       - name: Test
         run: bun test
 
-      - name: Smoke test (consumer install from tarball)
-        run: bash scripts/smoke-test.sh
+      - name: Build (tsc → dist/)
+        run: bun run build
 
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
+
+      - name: Smoke test (Bun consumer install from tarball)
+        run: bash scripts/smoke-test.sh
+
+      - name: Smoke test (Node consumer install from tarball)
+        run: bash scripts/smoke-test-node.sh
 
       # Trusted publishing requires npm >= 11.5.1.
       # Bootstrap npm 11 via direct tarball download — avoids using the

--- a/package.json
+++ b/package.json
@@ -13,19 +13,31 @@
     "access": "public",
     "provenance": true
   },
-  "main": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
   "bin": {
     "spores": "./src/cli/main.ts"
   },
   "files": [
-    "src/**/*.ts",
-    "!src/**/*.test.ts",
+    "dist/**/*.js",
+    "dist/**/*.d.ts",
+    "dist/**/*.map",
+    "src/cli/**/*.ts",
+    "!src/cli/**/*.test.ts",
     "AGENTS.md",
     "CHANGELOG.md"
   ],
   "scripts": {
+    "build": "tsc -p tsconfig.build.json",
     "typecheck": "tsc --noEmit",
-    "test": "bun test"
+    "test": "bun test",
+    "prepack": "bun run build"
   },
   "devDependencies": {
     "@types/bun": "^1.3.11",

--- a/scripts/smoke-consumer.mjs
+++ b/scripts/smoke-consumer.mjs
@@ -1,35 +1,30 @@
+#!/usr/bin/env node
 /**
- * Smoke-test consumer script.
+ * Plain-JS smoke consumer — validates `@tnezdev/spores` is importable and
+ * its public-API value exports are real functions/constructors. Same checks
+ * as smoke-consumer.ts, but compiled-free so it runs identically under
+ * Bun and Node.
  *
- * Runs inside a temp directory where @tnezdev/spores has been installed
- * from the npm-pack tarball. Validates that value exports are importable
- * and constructable under Bun.
- *
- * Usage: bun run scripts/smoke-consumer.ts <consumer-dir>
+ * Usage: node scripts/smoke-consumer.mjs <consumer-dir>
  */
+
+import { createRequire } from "node:module"
 
 const consumerDir = process.argv[2]
 if (!consumerDir) {
-  console.error("Usage: bun run smoke-consumer.ts <consumer-dir>")
+  console.error("Usage: smoke-consumer.mjs <consumer-dir>")
   process.exit(1)
 }
 
-// Resolve the installed package from the consumer's node_modules
-const pkgPath = `${consumerDir}/node_modules/@tnezdev/spores/src/index.ts`
+const require = createRequire(`${consumerDir}/`)
+const pkgName = "@tnezdev/spores"
+const mod = await import(require.resolve(pkgName))
 
-const mod = await import(pkgPath)
-
-const errors: string[] = []
-
-function check(name: string, condition: boolean) {
-  if (!condition) {
-    errors.push(`  FAIL: ${name}`)
-  } else {
-    console.log(`  OK: ${name}`)
-  }
+const errors = []
+function check(name, condition) {
+  if (!condition) errors.push(`  FAIL: ${name}`)
+  else console.log(`  OK: ${name}`)
 }
-
-// --- Value exports (these must be real, not just types) ---
 
 check("FilesystemAdapter is a constructor", typeof mod.FilesystemAdapter === "function")
 check("FilesystemWorkflowAdapter is a constructor", typeof mod.FilesystemWorkflowAdapter === "function")
@@ -47,6 +42,16 @@ check("loadPersona is a function", typeof mod.loadPersona === "function")
 check("activatePersona is a function", typeof mod.activatePersona === "function")
 check("resolveSituational is a function", typeof mod.resolveSituational === "function")
 check("fireHook is a function", typeof mod.fireHook === "function")
+
+// New in 0.4.0+
+check("InMemorySource is a constructor", typeof mod.InMemorySource === "function")
+check("FlatFileSource is a constructor", typeof mod.FlatFileSource === "function")
+check("NestedFileSource is a constructor", typeof mod.NestedFileSource === "function")
+check("LayeredSource is a constructor", typeof mod.LayeredSource === "function")
+check("loadPersonaFromSource is a function", typeof mod.loadPersonaFromSource === "function")
+check("loadSkillFromSource is a function", typeof mod.loadSkillFromSource === "function")
+check("loadGraphFromSource is a function", typeof mod.loadGraphFromSource === "function")
+check("matchDispatch is a function", typeof mod.matchDispatch === "function")
 
 if (errors.length > 0) {
   console.error("\nSmoke test failed:")

--- a/scripts/smoke-test-node.sh
+++ b/scripts/smoke-test-node.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Node smoke test for @tnezdev/spores
+#
+# Validates that the npm-packed tarball is consumable by Node.js (the
+# Bun-only constraint we lifted in #32). Mirrors smoke-test.sh but runs
+# the consumer under Node instead of Bun.
+#
+#   1. npm pack → tarball (prepack runs `bun run build` → dist/)
+#   2. Install tarball in a temp directory under npm
+#   3. Run the plain-JS consumer script with Node
+#
+# Usage: bash scripts/smoke-test-node.sh
+# Requires: bun (for build), npm, node
+#
+# This complements smoke-test.sh — both must pass before we ship.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMPDIR_BASE="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_BASE"' EXIT
+
+echo "==> Packing tarball (runs prepack → bun run build)..."
+TARBALL=$(cd "$REPO_ROOT" && npm pack --silent --pack-destination "$TMPDIR_BASE" 2>/dev/null)
+TARBALL_PATH="$TMPDIR_BASE/$TARBALL"
+
+if [ ! -f "$TARBALL_PATH" ]; then
+  echo "FAIL: npm pack did not produce a tarball"
+  exit 1
+fi
+echo "    Tarball: $TARBALL"
+
+echo "==> Setting up Node consumer project..."
+CONSUMER="$TMPDIR_BASE/consumer"
+mkdir -p "$CONSUMER"
+cat > "$CONSUMER/package.json" <<'PKG'
+{ "name": "smoke-consumer-node", "version": "0.0.0", "type": "module" }
+PKG
+
+echo "==> Installing from tarball under npm..."
+(cd "$CONSUMER" && npm install --silent "$TARBALL_PATH" 2>&1)
+
+echo "==> Running consumer script under Node..."
+node "$REPO_ROOT/scripts/smoke-consumer.mjs" "$CONSUMER"
+
+echo ""
+echo "==> Node smoke test passed."

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -15,8 +15,8 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 TMPDIR_BASE="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR_BASE"' EXIT
 
-echo "==> Packing tarball..."
-TARBALL=$(cd "$REPO_ROOT" && npm pack --pack-destination "$TMPDIR_BASE" 2>/dev/null)
+echo "==> Packing tarball (runs prepack → bun run build)..."
+TARBALL=$(cd "$REPO_ROOT" && npm pack --silent --pack-destination "$TMPDIR_BASE" 2>/dev/null)
 TARBALL_PATH="$TMPDIR_BASE/$TARBALL"
 
 if [ ! -f "$TARBALL_PATH" ]; then
@@ -36,7 +36,7 @@ echo "==> Installing from tarball..."
 (cd "$CONSUMER" && bun add "$TARBALL_PATH" 2>&1)
 
 echo "==> Running consumer script under Bun..."
-bun run "$REPO_ROOT/scripts/smoke-consumer.ts" "$CONSUMER"
+bun run "$REPO_ROOT/scripts/smoke-consumer.mjs" "$CONSUMER"
 
 echo ""
 echo "==> Smoke test passed."

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "allowImportingTsExtensions": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary

Lifts the Bun-only constraint. `@tnezdev/spores` now ships compiled `.js` + `.d.ts` in `dist/` on every pack, so Node and V8-isolate runtimes (Cloudflare Workers, Vercel Edge, etc.) can consume the package directly. Bun consumers are unaffected — they resolve through the same entry, just reading from `dist/index.js`.

This unblocks Compass: their agentic compute (CF "think" framework, V8 isolates) and `compass/www` (CF Workers) can now import spores' types, sources, and pure functions.

Closes #32.

## What changed

- **`tsconfig.build.json`** — extends main tsconfig, emits NodeNext modules to `dist/` with full `.d.ts` + source maps. Excludes test files. `bun run build` runs `tsc -p tsconfig.build.json`.
- **`package.json`** — `main` + `types` now point at `dist/`. `exports` field added for proper resolution. `prepack` script auto-builds before `npm pack`. `files` includes `dist/**/*.{js,d.ts,map}`; CLI sources still ship for the bin entry.
- **`scripts/smoke-consumer.mjs`** (replaces `.ts`) — plain-JS consumer that runs identically under Bun and Node. Verifies all 24 public-API value exports.
- **`scripts/smoke-test-node.sh`** (new) — Node-runtime smoke test mirroring `smoke-test.sh`. Both run in CI.
- **CI + publish workflows** — run build + both smoke tests before publish.

## Verified locally

- `bun test` → 342 pass, no regressions
- `bun run typecheck` → clean
- `smoke-test.sh` (Bun consumer) → all 24 exports OK
- `smoke-test-node.sh` (Node consumer) → all 24 exports OK

## What stays Bun-only

- **CLI bin entry** (`bin: ./src/cli/main.ts`). CLI changes are out of scope; library consumption is the priority. Bun users keep `npx spores` working.
- **`fireHook` and `wake/resolve`** internally use `Bun.spawn`. The modules import cleanly on Node (no top-level Bun reference), but invoking these specific functions on Node fails at runtime. Migration to `node:child_process` is deferred — Compass on Workers can't run child processes regardless of API choice.

## Caveats for Compass

- **Filesystem source impls won't work on Workers.** `FlatFileSource` and `NestedFileSource` import `node:fs` and `node:path` — those don't exist in the Workers runtime. The `Source` *interface* is universal; Workers consumers will need a Workers-native source (R2 binding, KV, D1). **That's the next PR — `R2BucketSource` + `KvSource` + `HttpSource`.**
- Pure stuff (`InMemorySource`, `LayeredSource`, `matchDispatch`, `activatePersona`, all types, all parsers) ports cleanly to Workers right now.

## Test plan

- [x] `bun test` pass
- [x] `bun run typecheck` pass
- [x] Bun smoke test pass
- [x] Node smoke test pass
- [ ] CI green on PR before merge