### PR TITLE
feat: HTTP, R2, and KV sources for Workers + remote consumers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,12 +5,15 @@
     "": {
       "name": "@tnezdev/spores",
       "devDependencies": {
+        "@cloudflare/workers-types": "^4.20260426.1",
         "@types/bun": "^1.3.11",
         "typescript": "^5.7.0",
       },
     },
   },
   "packages": {
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260426.1", "", {}, "sha512-cBYeQaWwv/jFV8ualmwp6wIxmAf0rDe2DPPQwPbslKmPHqgv861YpAvm45r05K40QboZgxNQVIPgNkmtHqZeJQ=="],
+
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
     "@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "prepack": "bun run build"
   },
   "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260426.1",
     "@types/bun": "^1.3.11",
     "typescript": "^5.7.0"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,9 @@ export { InMemorySource } from "./sources/in-memory.js"
 export { FlatFileSource } from "./sources/flat-file.js"
 export { NestedFileSource } from "./sources/nested-file.js"
 export { LayeredSource } from "./sources/layered.js"
+export { HttpSource, type UrlForName } from "./sources/http.js"
+export { R2BucketSource } from "./sources/r2.js"
+export { KvSource } from "./sources/kv.js"
 
 export { match as matchDispatch } from "./dispatch/match.js"
 

--- a/src/sources/http.test.ts
+++ b/src/sources/http.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "bun:test"
+import { HttpSource } from "./http.js"
+
+function makeFetcher(
+  routes: Record<string, { status: number; body?: string; statusText?: string }>,
+): typeof fetch {
+  return (async (input: string | URL | Request) => {
+    const url = typeof input === "string" ? input : input.toString()
+    const route = routes[url]
+    if (route === undefined) {
+      return new Response("not configured", { status: 500 })
+    }
+    return new Response(route.body ?? "", {
+      status: route.status,
+      statusText: route.statusText ?? "",
+    })
+  }) as typeof fetch
+}
+
+describe("HttpSource", () => {
+  test("read returns text + url locator on 200", async () => {
+    const fetcher = makeFetcher({
+      "https://cdn.example/personas/dottie.md": { status: 200, body: "hello" },
+    })
+    const source = new HttpSource({
+      urlForName: (n) => `https://cdn.example/personas/${n}.md`,
+      fetcher,
+    })
+    const record = await source.read("dottie")
+    expect(record).toEqual({
+      text: "hello",
+      locator: "https://cdn.example/personas/dottie.md",
+    })
+  })
+
+  test("read returns undefined on 404", async () => {
+    const fetcher = makeFetcher({
+      "https://cdn.example/missing.md": { status: 404 },
+    })
+    const source = new HttpSource({
+      urlForName: (n) => `https://cdn.example/${n}.md`,
+      fetcher,
+    })
+    expect(await source.read("missing")).toBeUndefined()
+  })
+
+  test("read throws on non-404 error responses", async () => {
+    const fetcher = makeFetcher({
+      "https://cdn.example/dottie.md": {
+        status: 500,
+        statusText: "Internal Server Error",
+      },
+    })
+    const source = new HttpSource({
+      urlForName: (n) => `https://cdn.example/${n}.md`,
+      fetcher,
+    })
+    expect(source.read("dottie")).rejects.toThrow(/500/)
+  })
+
+  test("urlForName lets the caller encode any URL convention", async () => {
+    const seen: string[] = []
+    const fetcher = (async (url: string | URL | Request) => {
+      seen.push(typeof url === "string" ? url : url.toString())
+      return new Response("ok", { status: 200 })
+    }) as typeof fetch
+    const source = new HttpSource({
+      urlForName: (n) => `https://api.example/v1/personas?name=${encodeURIComponent(n)}`,
+      fetcher,
+    })
+    await source.read("dottie weaver")
+    expect(seen[0]).toBe(
+      "https://api.example/v1/personas?name=dottie%20weaver",
+    )
+  })
+
+  test("custom fetcher sees the request — auth/signing happens here", async () => {
+    let signedHeader: string | undefined
+    const fetcher = (async (url: string | URL | Request, init?: RequestInit) => {
+      const headers = new Headers(init?.headers)
+      signedHeader = headers.get("authorization") ?? undefined
+      return new Response("body", { status: 200 })
+    }) as typeof fetch
+
+    const signing: typeof fetch = (async (url, init = {}) => {
+      const headers = new Headers(init.headers)
+      headers.set("authorization", "Signed test-token")
+      return fetcher(url, { ...init, headers })
+    }) as typeof fetch
+
+    const source = new HttpSource({
+      urlForName: () => "https://api.example/x",
+      fetcher: signing,
+    })
+    await source.read("anything")
+    expect(signedHeader).toBe("Signed test-token")
+  })
+
+  test("list throws when no listFromIndex is provided", async () => {
+    const source = new HttpSource({
+      urlForName: () => "https://x",
+      fetcher: makeFetcher({}),
+    })
+    expect(source.list()).rejects.toThrow(/listFromIndex/)
+  })
+
+  test("list returns sorted names from listFromIndex", async () => {
+    const source = new HttpSource({
+      urlForName: () => "https://x",
+      fetcher: makeFetcher({}),
+      listFromIndex: async () => ["zebra", "alpha", "mike"],
+    })
+    expect(await source.list()).toEqual(["alpha", "mike", "zebra"])
+  })
+})

--- a/src/sources/http.ts
+++ b/src/sources/http.ts
@@ -1,0 +1,81 @@
+import type { Source, SourceRecord } from "./source.js"
+
+/**
+ * Resolves a record name to the URL its body lives at. Pure function;
+ * the source calls it once per `read`. Use this seam to encode whatever
+ * URL convention the upstream service prefers (path style, query
+ * parameters, prefix layouts, content-addressed digests, etc.).
+ */
+export type UrlForName = (name: string) => string
+
+/**
+ * A `Source` over HTTP — fetches each record's body from a URL derived
+ * from its name. Universal: works on Bun, Node 18+, Workers, browsers,
+ * anywhere `fetch` exists.
+ *
+ * The source is auth-agnostic. Callers wanting signed requests (S3, R2
+ * via S3 API, private CDN, etc.) inject a custom `fetcher` that wraps
+ * `globalThis.fetch` with whatever signing logic they need. Spores
+ * stays out of credential management.
+ *
+ * `list` is intentionally minimal — over plain HTTP there's no portable
+ * way to enumerate names. If the upstream service exposes a listing
+ * endpoint (S3 ListObjectsV2, KV list keys, etc.), wrap that in
+ * `listFromIndex` and pass it in. Otherwise `list` is unsupported and
+ * throws — which is the right failure mode for a discovery operation
+ * that fundamentally cannot be performed.
+ *
+ * @example
+ *   // GitHub raw — public, no auth, name-as-filename
+ *   new HttpSource({
+ *     urlForName: (name) => `https://raw.githubusercontent.com/org/repo/main/personas/${name}.md`,
+ *   })
+ *
+ * @example
+ *   // R2 via S3 API — caller provides SigV4-signing fetcher
+ *   new HttpSource({
+ *     urlForName: (name) => `${endpoint}/${bucket}/personas/${name}.md`,
+ *     fetcher: signedFetch,
+ *     listFromIndex: async () => listKeys(endpoint, bucket, "personas/"),
+ *   })
+ */
+export class HttpSource implements Source {
+  private readonly urlForName: UrlForName
+  private readonly fetcher: typeof fetch
+  private readonly listFromIndex?: () => Promise<string[]>
+
+  constructor(opts: {
+    urlForName: UrlForName
+    fetcher?: typeof fetch
+    listFromIndex?: () => Promise<string[]>
+  }) {
+    this.urlForName = opts.urlForName
+    this.fetcher = opts.fetcher ?? globalThis.fetch
+    if (opts.listFromIndex !== undefined) {
+      this.listFromIndex = opts.listFromIndex
+    }
+  }
+
+  async read(name: string): Promise<SourceRecord | undefined> {
+    const url = this.urlForName(name)
+    const response = await this.fetcher(url)
+    if (response.status === 404) return undefined
+    if (!response.ok) {
+      throw new Error(
+        `HttpSource.read(${name}): ${response.status} ${response.statusText} (${url})`,
+      )
+    }
+    const text = await response.text()
+    return { text, locator: url }
+  }
+
+  async list(): Promise<string[]> {
+    if (this.listFromIndex === undefined) {
+      throw new Error(
+        "HttpSource.list() is not supported — pass `listFromIndex` to the constructor if your upstream service can enumerate names.",
+      )
+    }
+    const names = await this.listFromIndex()
+    return [...names].sort()
+  }
+}

--- a/src/sources/kv.test.ts
+++ b/src/sources/kv.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test"
+import type { KVNamespace } from "@cloudflare/workers-types"
+import { KvSource } from "./kv.js"
+
+function fakeKv(entries: Record<string, string>): KVNamespace {
+  return {
+    async get(key: string, _format?: "text") {
+      return entries[key] ?? null
+    },
+    async list(opts?: { prefix?: string; cursor?: string }) {
+      const prefix = opts?.prefix ?? ""
+      const matching = Object.keys(entries)
+        .filter((k) => k.startsWith(prefix))
+        .sort()
+      return {
+        keys: matching.map((name) => ({ name })),
+        list_complete: true,
+        cursor: undefined,
+      }
+    },
+  } as unknown as KVNamespace
+}
+
+describe("KvSource", () => {
+  test("read returns text + kv: locator on hit", async () => {
+    const kv = fakeKv({ "personas:dottie": "hello" })
+    const source = new KvSource({ kv, prefix: "personas:" })
+    const record = await source.read("dottie")
+    expect(record).toEqual({ text: "hello", locator: "kv:personas:dottie" })
+  })
+
+  test("read returns undefined when key is missing", async () => {
+    const kv = fakeKv({})
+    const source = new KvSource({ kv })
+    expect(await source.read("missing")).toBeUndefined()
+  })
+
+  test("list strips prefix from keys, returns sorted names", async () => {
+    const kv = fakeKv({
+      "personas:zebra": "z",
+      "personas:alpha": "a",
+      "personas:mike": "m",
+      "skills:elsewhere": "x",
+    })
+    const source = new KvSource({ kv, prefix: "personas:" })
+    expect(await source.list()).toEqual(["alpha", "mike", "zebra"])
+  })
+
+  test("list with ext filter excludes non-matching keys", async () => {
+    const kv = fakeKv({
+      "alpha.md": "ok",
+      "alpha.json": "wrong",
+      "README": "no ext",
+    })
+    const source = new KvSource({ kv, ext: ".md" })
+    expect(await source.list()).toEqual(["alpha"])
+  })
+
+  test("default prefix empty, default ext empty — keys used as-is", async () => {
+    const kv = fakeKv({ dottie: "ok" })
+    const source = new KvSource({ kv })
+    const record = await source.read("dottie")
+    expect(record).toEqual({ text: "ok", locator: "kv:dottie" })
+  })
+
+  test("list paginates via cursor until list_complete", async () => {
+    let calls = 0
+    const kv = {
+      async get(_key: string) {
+        return null
+      },
+      async list(opts?: { prefix?: string; cursor?: string }) {
+        calls++
+        if (opts?.cursor === undefined) {
+          return {
+            keys: [{ name: "alpha" }],
+            list_complete: false,
+            cursor: "page-2",
+          }
+        }
+        return {
+          keys: [{ name: "zebra" }],
+          list_complete: true,
+          cursor: undefined,
+        }
+      },
+    } as unknown as KVNamespace
+
+    const source = new KvSource({ kv })
+    expect(await source.list()).toEqual(["alpha", "zebra"])
+    expect(calls).toBe(2)
+  })
+})

--- a/src/sources/kv.ts
+++ b/src/sources/kv.ts
@@ -1,0 +1,64 @@
+import type { KVNamespace } from "@cloudflare/workers-types"
+import type { Source, SourceRecord } from "./source.js"
+
+/**
+ * A `Source` backed by a Cloudflare KV namespace binding. Layout:
+ * `<prefix><name>` — KV doesn't have file extensions, so naming is
+ * caller's choice. The optional `ext` is only stripped on listing
+ * (for consistency with file-style sources where `<name>.md` lists
+ * as `<name>`); read-by-name uses the bare key as given.
+ *
+ * KV's eventual consistency means newly-written records may not be
+ * immediately readable globally. That's a service-level concern, not
+ * one this source can paper over.
+ *
+ * @example
+ *   const source = new KvSource({
+ *     kv: env.PERSONAS_KV,
+ *     prefix: "personas:",
+ *   })
+ *   const persona = await loadPersonaFromSource("dottie", source)
+ *   // Reads key `personas:dottie` from KV.
+ */
+export class KvSource implements Source {
+  private readonly kv: KVNamespace
+  private readonly prefix: string
+  private readonly ext: string
+
+  constructor(opts: { kv: KVNamespace; prefix?: string; ext?: string }) {
+    this.kv = opts.kv
+    this.prefix = opts.prefix ?? ""
+    this.ext = opts.ext ?? ""
+  }
+
+  async read(name: string): Promise<SourceRecord | undefined> {
+    const key = `${this.prefix}${name}${this.ext}`
+    const text = await this.kv.get(key, "text")
+    if (text === null) return undefined
+    return { text, locator: `kv:${key}` }
+  }
+
+  async list(): Promise<string[]> {
+    const names = new Set<string>()
+    let cursor: string | undefined
+    while (true) {
+      const result = await this.kv.list(
+        cursor === undefined
+          ? { prefix: this.prefix }
+          : { prefix: this.prefix, cursor },
+      )
+      for (const entry of result.keys) {
+        if (this.ext.length > 0 && !entry.name.endsWith(this.ext)) continue
+        const stripped = entry.name.slice(
+          this.prefix.length,
+          this.ext.length > 0 ? entry.name.length - this.ext.length : entry.name.length,
+        )
+        if (stripped.length > 0) names.add(stripped)
+      }
+      if (result.list_complete) break
+      cursor = result.cursor ?? undefined
+    }
+
+    return Array.from(names).sort()
+  }
+}

--- a/src/sources/r2.test.ts
+++ b/src/sources/r2.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test"
+import type { R2Bucket } from "@cloudflare/workers-types"
+import { R2BucketSource } from "./r2.js"
+
+// Minimal in-memory R2 fake — just the bits R2BucketSource consumes.
+function fakeR2(entries: Record<string, string>): R2Bucket {
+  return {
+    async get(key: string) {
+      const body = entries[key]
+      if (body === undefined) return null
+      return {
+        async text() {
+          return body
+        },
+      }
+    },
+    async list(opts?: { prefix?: string; cursor?: string }) {
+      const prefix = opts?.prefix ?? ""
+      const matching = Object.keys(entries)
+        .filter((k) => k.startsWith(prefix))
+        .sort()
+      return {
+        objects: matching.map((key) => ({ key })),
+        truncated: false,
+        cursor: undefined,
+      }
+    },
+  } as unknown as R2Bucket
+}
+
+describe("R2BucketSource", () => {
+  test("read returns text + r2: locator on hit", async () => {
+    const bucket = fakeR2({ "personas/dottie.md": "hello" })
+    const source = new R2BucketSource({ bucket, prefix: "personas/", ext: ".md" })
+    const record = await source.read("dottie")
+    expect(record).toEqual({ text: "hello", locator: "r2:personas/dottie.md" })
+  })
+
+  test("read returns undefined when key is missing", async () => {
+    const bucket = fakeR2({})
+    const source = new R2BucketSource({ bucket })
+    expect(await source.read("missing")).toBeUndefined()
+  })
+
+  test("list returns names with prefix and ext stripped, sorted", async () => {
+    const bucket = fakeR2({
+      "personas/zebra.md": "z",
+      "personas/alpha.md": "a",
+      "personas/mike.md": "m",
+      "skills/elsewhere.md": "x",
+    })
+    const source = new R2BucketSource({ bucket, prefix: "personas/", ext: ".md" })
+    expect(await source.list()).toEqual(["alpha", "mike", "zebra"])
+  })
+
+  test("list ignores non-matching extension", async () => {
+    const bucket = fakeR2({
+      "alpha.md": "ok",
+      "alpha.json": "wrong",
+      "README": "no ext",
+    })
+    const source = new R2BucketSource({ bucket, ext: ".md" })
+    expect(await source.list()).toEqual(["alpha"])
+  })
+
+  test("default prefix is empty, default ext is .md", async () => {
+    const bucket = fakeR2({ "dottie.md": "ok" })
+    const source = new R2BucketSource({ bucket })
+    const record = await source.read("dottie")
+    expect(record).toEqual({ text: "ok", locator: "r2:dottie.md" })
+  })
+
+  test("list paginates via cursor", async () => {
+    let calls = 0
+    const bucket = {
+      async get(_key: string) {
+        return null
+      },
+      async list(opts?: { prefix?: string; cursor?: string }) {
+        calls++
+        if (opts?.cursor === undefined) {
+          return {
+            objects: [{ key: "alpha.md" }],
+            truncated: true,
+            cursor: "page-2",
+          }
+        }
+        return {
+          objects: [{ key: "zebra.md" }],
+          truncated: false,
+          cursor: undefined,
+        }
+      },
+    } as unknown as R2Bucket
+
+    const source = new R2BucketSource({ bucket, ext: ".md" })
+    expect(await source.list()).toEqual(["alpha", "zebra"])
+    expect(calls).toBe(2)
+  })
+})

--- a/src/sources/r2.ts
+++ b/src/sources/r2.ts
@@ -1,0 +1,61 @@
+import type { R2Bucket } from "@cloudflare/workers-types"
+import type { Source, SourceRecord } from "./source.js"
+
+/**
+ * A `Source` backed by a Cloudflare R2 bucket binding. Inside Workers,
+ * use the binding directly — it's an in-process call, no edge round-trip.
+ * For external-to-Workers consumers, prefer `HttpSource` with an
+ * S3-compatible signed fetcher.
+ *
+ * Layout: `<prefix><name><ext>`. Defaults match the persona/skill/workflow
+ * conventions but apply to any flat-keyed object store.
+ *
+ * @example
+ *   // In a Worker handler
+ *   const source = new R2BucketSource({
+ *     bucket: env.PERSONAS_BUCKET,
+ *     prefix: "personas/",
+ *     ext: ".md",
+ *   })
+ *   const persona = await loadPersonaFromSource("dottie", source)
+ */
+export class R2BucketSource implements Source {
+  private readonly bucket: R2Bucket
+  private readonly prefix: string
+  private readonly ext: string
+
+  constructor(opts: { bucket: R2Bucket; prefix?: string; ext?: string }) {
+    this.bucket = opts.bucket
+    this.prefix = opts.prefix ?? ""
+    this.ext = opts.ext ?? ".md"
+  }
+
+  async read(name: string): Promise<SourceRecord | undefined> {
+    const key = `${this.prefix}${name}${this.ext}`
+    const obj = await this.bucket.get(key)
+    if (obj === null) return undefined
+    const text = await obj.text()
+    return { text, locator: `r2:${key}` }
+  }
+
+  async list(): Promise<string[]> {
+    const names = new Set<string>()
+    let cursor: string | undefined
+    do {
+      const result = await this.bucket.list(
+        cursor === undefined
+          ? { prefix: this.prefix }
+          : { prefix: this.prefix, cursor },
+      )
+      for (const obj of result.objects) {
+        if (!obj.key.endsWith(this.ext)) continue
+        const stripped = obj.key
+          .slice(this.prefix.length, obj.key.length - this.ext.length)
+        if (stripped.length > 0) names.add(stripped)
+      }
+      cursor = result.truncated ? result.cursor : undefined
+    } while (cursor !== undefined)
+
+    return Array.from(names).sort()
+  }
+}


### PR DESCRIPTION
## Summary

Three new `Source` implementations cover the storage backends Compass needs on Cloudflare Workers (and any other V8-isolate or HTTP consumer). All three plug into the existing `Source` interface — no contract changes; they compose into `LayeredSource` for seed-then-emerge layouts the same way `FlatFileSource` does.

Pairs with #43 (the build pipeline). Build verification lands once #43 merges.

## What ships

### `HttpSource` — universal, fetch-based

- Generic over any URL convention via a `urlForName(name): string` seam.
- Auth-agnostic: callers inject a custom `fetcher` for SigV4-signed S3/R2 requests, bearer tokens, or anything else. **Spores stays out of credential management entirely.**
- `list()` requires an opt-in `listFromIndex` callback — over plain HTTP there's no portable enumeration, and silently returning `[]` would hide real bugs.

### `R2BucketSource` — Cloudflare R2 binding wrapper

- Reads `<prefix><name><ext>` from an `R2Bucket` binding. Inside Workers this is in-process, no edge round-trip.
- `list()` paginates via R2's cursor automatically.
- For external-to-Workers consumers, prefer `HttpSource` with an S3-compatible signed fetcher.

### `KvSource` — Cloudflare KV namespace binding wrapper

- Reads `<prefix><name><ext>` from a `KVNamespace` binding. KV doesn't have file extensions natively; `ext` defaults to empty.
- `list()` paginates via KV's cursor until `list_complete`.

## Why these in spores core (vs Compass-side)

The cost is so low (5–30 lines per source) and the abstractions are so general that pushing them to Compass-side would mean every consumer reimplements the same wiring. Better here, where they get tested and stay aligned with the `Source` contract as it evolves.

## What stays Compass-side

- **Auth/credential management** — `HttpSource` accepts a fetcher; `R2BucketSource` and `KvSource` take pre-bound bindings. Compass passes whatever signed fetcher or binding their deployment provides.
- **Workers-native sources we haven't seen demand for yet** — D1, Durable Objects, R2 multipart uploads. Add when a real consumer needs them.

## Compass example

```ts
const personas = new LayeredSource([
  new R2BucketSource({ bucket: env.LIVE_PERSONAS, prefix: "" }),
  new HttpSource({
    urlForName: (n) => `${SEED_URL}/personas/${n}.md`,
    fetcher,
  }),
])
const persona = await loadPersonaFromSource("dottie", personas)
```

Live R2 state shadows seed HTTP fallback. Same seed-then-emerge shape as the filesystem layered approach in the spores dogfood.

## Implementation notes

- Tests use **mock fetchers** (`HttpSource`) and **in-memory fakes** for the binding API surface (`R2BucketSource`, `KvSource`). No real Workers runtime needed — that's a feature of the abstraction.
- Adds `@cloudflare/workers-types` as a devDep, symmetric to `@types/bun`.
- The Workers types stay out of emitted `.d.ts` because the source modules re-import only the bits they need (`R2Bucket`, `KVNamespace`).

## Test plan

- [x] `bun test` → 361 pass (+19 new)
- [x] `bun run typecheck` → clean
- [ ] Once #43 lands and this rebases, both Bun + Node smoke tests pass
- [ ] CI green on this PR before merge