### PR TITLE
chore: release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to `@tnezdev/spores`. Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follows [semver](https://semver.org/).
 
+## 0.4.1 — 2026-04-27
+
+The Workers/Node release. Lifts the Bun-only constraint and ships three new `Source` implementations covering the storage backends Cloudflare Workers consumers need.
+
+### Added
+
+- **Node + V8-isolate consumption.** `tsc` build pipeline emits compiled `.js` + `.d.ts` to `dist/` on every pack. Node, Cloudflare Workers, Vercel Edge, and any other non-Bun runtime can now consume `@tnezdev/spores` from npm directly. Bun consumers are unaffected — the package entry resolves to the same compiled output. (closes #32)
+- **`HttpSource`** — universal `fetch`-based source. Auth-agnostic (callers inject custom fetcher for SigV4 / bearer tokens / etc.). Optional `listFromIndex` callback for upstreams that expose enumeration.
+- **`R2BucketSource`** — Cloudflare R2 binding wrapper. In-process reads inside Workers, automatic cursor pagination on `list()`. For external-to-Workers consumers, prefer `HttpSource` with an S3-compatible signed fetcher.
+- **`KvSource`** — Cloudflare KV namespace binding wrapper. Cursor pagination via `list_complete`. Default empty `ext` (KV doesn't have file extensions natively).
+
+### Changed
+
+- Bun + Node smoke tests now run in CI on every PR (previously only on publish).
+- `prepack` script auto-builds before `npm pack` — packing always ships fresh `dist/`.
+- `scripts/smoke-consumer.mjs` replaces `smoke-consumer.ts` — plain JS runs identically under both Bun and Node.
+
+### Notes
+
+- The CLI bin entry (`bin: ./src/cli/main.ts`) remains Bun-only. CLI changes are out of scope; library consumption is the priority.
+- `fireHook` and `wake/resolve` internally use `Bun.spawn`. The modules import cleanly on Node, but invoking these specific functions on Node fails at runtime. Migration to `node:child_process` is deferred — Workers can't run child processes regardless of API choice.
+- Compass on Workers: `FlatFileSource` and `NestedFileSource` (which use `node:fs`) won't work; use `R2BucketSource` / `KvSource` / `HttpSource` instead. Pure pieces (`InMemorySource`, `LayeredSource`, `matchDispatch`, `activatePersona`, parsers, all types) port cleanly.
+
 ## 0.4.0 — 2026-04-27
 
 The boundary-work release. Compass and other remote runtimes can now load every config-style primitive from any storage backend, and Dispatch foundation types pin the universal inbound message shape. All additions are backward-compatible.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tnezdev/spores",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Executable toolbelt for agent self-improvement",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

The Workers/Node release. Lifts the Bun-only constraint and ships three new `Source` implementations covering the storage backends Cloudflare Workers consumers need. Closes #32.

All additions are backward-compatible.

## Changes since v0.4.0

- **#43** — `tsc` build pipeline for Node + Workers consumption
- **#44** — `HttpSource`, `R2BucketSource`, `KvSource`

Full details in `CHANGELOG.md`.

## What this unlocks

- **Compass agentic compute** (CF "think" framework, V8 isolates) and **`compass/www`** (CF Workers) can now consume `@tnezdev/spores` directly.
- Node-based services and tooling (anything not Bun) can install and use spores.
- Workers consumers get `R2BucketSource` and `KvSource` out of the box; no boilerplate.

## Test plan

- [x] `bun test` — 361 pass
- [x] `bun run typecheck` — clean
- [x] Bun smoke test pass
- [x] Node smoke test pass
- [x] `dependencies: {}` preserved
- [ ] CI green on this PR before merge
- [ ] After merge: tag `v0.4.1`; watch `publish.yml`
- [ ] Verify `npm view @tnezdev/spores version` returns `0.4.1`
- [ ] Run `bash scripts/post-publish-check.sh 0.4.1`