### PR TITLE
fix: post-publish-check.sh references renamed smoke-consumer

### DIFF
--- a/scripts/post-publish-check.sh
+++ b/scripts/post-publish-check.sh
@@ -34,7 +34,7 @@ INSTALLED=$(cd "$CONSUMER" && bun -e "const p = require('./node_modules/@tnezdev
 echo "    Installed version: ${INSTALLED}"
 
 echo "==> Running consumer script under Bun..."
-bun run "$REPO_ROOT/scripts/smoke-consumer.ts" "$CONSUMER"
+bun run "$REPO_ROOT/scripts/smoke-consumer.mjs" "$CONSUMER"
 
 echo ""
 echo "==> Post-publish check passed (${PKG})."


### PR DESCRIPTION
## Summary

#43 renamed `scripts/smoke-consumer.ts` → `smoke-consumer.mjs` but missed updating `scripts/post-publish-check.sh`, which still referenced the old `.ts` path.

## How it surfaced

During v0.4.1 release verification — the post-publish check failed with:

```
error: Module not found "/Users/tnez/Code/tnezdev/spores/scripts/smoke-consumer.ts"
```

Worked around manually by invoking `bun run scripts/smoke-consumer.mjs <consumer-dir>` directly against the just-published package. v0.4.1 itself is verified and shipping; this fix only prevents the script from breaking on the next release.

## Test plan

- [x] One-line change, the only thing it does is reference the renamed file
- [ ] CI green