### PR TITLE
feat: promote artifact to core SPORES primitive

### DIFF
--- a/.spores/hooks/artifact.written
+++ b/.spores/hooks/artifact.written
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# .spores/hooks/artifact.written
+#
+# Fires after `spores artifact write <id>` or `spores artifact edit <id>`
+# has persisted a new version to disk.
+# Indexes the artifact reference into memory so it can be recalled by type,
+# title, or version via `spores memory recall`.
+#
+# Contract — env vars set by spores:
+#   SPORES_EVENT            = "artifact.written" | "artifact.edited"
+#   SPORES_BIN              = path to the spores CLI entry (for callbacks)
+#   SPORES_ARTIFACT_ID      = the artifact ULID
+#   SPORES_ARTIFACT_VERSION = the new version number (as a string)
+#   SPORES_ARTIFACT_MODE    = write mode: "iterate" | "replace"
+#
+# Stdout from this script is appended to the command output.
+# Non-zero exit is surfaced as a warning — it does not fail the write.
+
+set -euo pipefail
+
+ID="${SPORES_ARTIFACT_ID:-}"
+VERSION="${SPORES_ARTIFACT_VERSION:-}"
+MODE="${SPORES_ARTIFACT_MODE:-}"
+
+# Exit quietly if no artifact info to work with
+[[ -z "$ID" ]] && exit 0
+
+# Build memory content
+CONTENT="Artifact written: ${ID} v${VERSION} (mode: ${MODE})"
+
+# SPORES_BIN may be a path to main.ts (dev) or the installed `spores` binary.
+if [[ "$SPORES_BIN" == *.ts ]]; then
+  invoke() { bun "$SPORES_BIN" "$@"; }
+else
+  invoke() { "$SPORES_BIN" "$@"; }
+fi
+
+# Store with a stable key so iterate writes update rather than duplicate
+invoke memory remember "$CONTENT" \
+  --key "artifact-written:${ID}" \
+  --tags "artifact-written" \
+  --tier L1 || true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,9 @@ A TypeScript library + CLI for agent in-loop primitives:
 3. **Workflow** — digraph runtime (GraphDef → Run → Transitions, state derived from history)
 4. **Tasks** — typed adapter interface (ULID IDs, Taskwarrior-shaped)
 5. **Persona** — activate a hat at the start of a turn: metadata (memory_tags, skills, task_filter, workflow, routing hints) + a rendered body with live situational facts. Declarative attention, not enforced scope.
-6. **Source** — pluggable read-only loader abstraction (`read(name) → text`, `list() → names`). Personas/skills/workflows all load through the same shape. `LayeredSource` composes for seed-then-emerge (e.g. live DB shadows seed filesystem). See "Source abstraction" below.
-7. **Dispatch** — foundation types for the universal inbound message primitive (`Dispatch`, `DispatchFilter`, `matchDispatch`). Spores ships the message shape and pure match logic; runtimes ship transport, scheduling, and handler execution.
+6. **Artifact** — versioned content blobs with metadata (type, title, tags, lock). The canonical place to store an agent's durable outputs within a project — briefs, memos, reports, plans. See "Artifact primitive" below.
+7. **Source** — pluggable read-only loader abstraction (`read(name) → text`, `list() → names`). Personas/skills/workflows all load through the same shape. `LayeredSource` composes for seed-then-emerge (e.g. live DB shadows seed filesystem). See "Source abstraction" below.
+8. **Dispatch** — foundation types for the universal inbound message primitive (`Dispatch`, `DispatchFilter`, `matchDispatch`). Spores ships the message shape and pure match logic; runtimes ship transport, scheduling, and handler execution.
 
 MVP scope = what an agent reaches for *inside a single turn*. No hosting, no webhooks, no session layer — those are daemon-level concerns. **Identity lives outside spores** — in the run orchestration layer. Spores provides the hat; the caller provides who's wearing it.
 
@@ -50,6 +51,7 @@ Every primitive has an interface in `src/<module>/adapter.ts`. Filesystem implem
 | workflow | `WorkflowAdapter` | `src/workflow/filesystem.ts` |
 | tasks | `TaskAdapter` | `src/tasks/adapter.ts` (stub only) |
 | personas | `PersonaAdapter` | `src/personas/filesystem.ts` |
+| artifacts | `ArtifactAdapter` | `src/artifact/filesystem.ts` |
 
 ### Source abstraction
 
@@ -87,6 +89,7 @@ Current command surface:
 - `spores skill list/show/run`
 - `spores workflow list/show/run/status`
 - `spores persona list/view/activate`
+- `spores artifact create/read/write/edit/inspect/list/lock`
 
 ### Skills on disk
 
@@ -144,6 +147,67 @@ See `PROJECTS/spores/DESIGN-runtime-description.md` for the full design conversa
 - Error handling: functions throw on unexpected errors; return `undefined` for "not found" cases (e.g. `loadSkill` returns `undefined` when skill doesn't exist)
 - No `console.log` in library code — CLI output goes through `output(ctx, data, formatter)` in `src/cli/main.ts`
 - **Descriptions are agent-facing activation triggers, not labels.** For both skills and personas, phrase `description` as "Activate when..." rather than "The X maintainer". `list` output is meant to function as a lookup table an agent scans to decide what to reach for — good triggers make the scan useful.
+
+### Artifact primitive
+
+Artifacts are versioned markdown blobs — the agent's durable output store for a project.
+
+**On-disk layout** (inside `.spores/artifacts/`):
+
+```
+.spores/artifacts/<ulid>/meta.json    — ArtifactRecord (type, title, version, locked, tags, …)
+.spores/artifacts/<ulid>/v1.md        — body at version 1
+.spores/artifacts/<ulid>/v2.md        — body at version 2 (iterate write)
+```
+
+`body_ref` in `meta.json` is relative to `.spores/artifacts/` — e.g. `"<id>/v2.md"`.
+
+**Write modes:**
+
+| Mode | Behavior |
+|------|----------|
+| `iterate` (default) | Bump version, write `v<n+1>.md`. Prior versions remain on disk. |
+| `replace` | Overwrite current `v<n>.md` in place. Version unchanged. |
+| `create` | Fail with "already exists". Used only for first-write semantics. |
+
+**Lock semantics:** `artifact lock <id>` sets `locked=true` in `meta.json`. Locked artifacts reject `write` and `edit`. `lock` is idempotent — locking an already-locked artifact is a no-op.
+
+**CLI worked example:**
+
+```bash
+# Create
+spores artifact create brief "## Q2 Launch\n\nTBD." --title "Q2 Brief" --tags "q2,launch"
+
+# Read (pipe-friendly — raw body to stdout in human mode, JSON with --json)
+spores artifact read 01JXYZ... | pbcopy
+
+# Iterate
+spores artifact write 01JXYZ... "## Q2 Launch\n\nUpdated content." --mode iterate
+
+# Targeted edit
+spores artifact edit 01JXYZ... --old "TBD." --new "Final copy."
+
+# Inspect metadata
+spores artifact inspect 01JXYZ... --json
+
+# List with filter
+spores artifact list --type brief --json
+
+# Lock the final version
+spores artifact lock 01JXYZ...
+```
+
+**Hook events:**
+
+| Event | Fired by |
+|-------|---------|
+| `artifact.created` | `artifact create` |
+| `artifact.written` | `artifact write`, `artifact edit` |
+| `artifact.locked` | `artifact lock` |
+
+Hook env vars: `SPORES_ARTIFACT_ID`, `SPORES_ARTIFACT_TYPE`, `SPORES_ARTIFACT_TITLE`, `SPORES_ARTIFACT_TAGS` (create); `SPORES_ARTIFACT_ID`, `SPORES_ARTIFACT_VERSION`, `SPORES_ARTIFACT_MODE` (written); `SPORES_ARTIFACT_ID`, `SPORES_ARTIFACT_FINAL_VERSION` (locked).
+
+**Dogfood hook:** `.spores/hooks/artifact.written` — indexes the artifact reference into memory after every write so it's searchable via `spores memory recall`.
 
 ## What NOT to add
 

--- a/src/artifact/adapter.ts
+++ b/src/artifact/adapter.ts
@@ -1,0 +1,81 @@
+import type {
+  ArtifactId,
+  ArtifactMetadata,
+  ArtifactQuery,
+  ArtifactRecord,
+  ArtifactRef,
+  ArtifactWriteMode,
+} from "../types.js"
+
+export interface CreateArtifactInput {
+  type: string
+  title: string
+  body: string | ReadableStream
+  tags?: string[] | undefined
+  derived_from?: ArtifactId | undefined
+}
+
+export interface WriteArtifactInput {
+  body: string | ReadableStream
+  mode?: ArtifactWriteMode | undefined // defaults to "iterate"
+}
+
+/**
+ * Adapter interface for durable artifact storage.
+ *
+ * An artifact is a named, versioned piece of content — addressable by ULID,
+ * persistable across turns, lockable for append-only history.
+ *
+ * Storage implementations (filesystem, blob) are separate from this interface.
+ * The filesystem adapter (`FilesystemArtifactAdapter`) is the default.
+ */
+export interface ArtifactAdapter {
+  /**
+   * Create a new artifact. `id`, `version`, `locked`, `created_at`, and
+   * `updated_at` are set by the adapter.
+   */
+  create(input: CreateArtifactInput): Promise<ArtifactRecord>
+
+  /**
+   * Read the body of an artifact. Returns the content as a string.
+   * Pass `version` to read a specific version; omit for the current version.
+   */
+  read(id: ArtifactId, opts?: { version?: number | undefined }): Promise<string>
+
+  /**
+   * Write new content to an artifact.
+   * - `iterate` (default) — bump version, prior version remains accessible
+   * - `replace` — overwrite current version in place
+   * - `create` — fail if the artifact already exists
+   *
+   * Fails if the artifact is locked.
+   */
+  write(id: ArtifactId, input: WriteArtifactInput): Promise<ArtifactRecord>
+
+  /**
+   * Edit artifact body by replacing `oldStr` with `newStr`.
+   * Semantically equivalent to a `write` with mode `iterate`.
+   * Throws if `oldStr` is not found in the current body.
+   * Fails if the artifact is locked.
+   */
+  edit(id: ArtifactId, oldStr: string, newStr: string): Promise<ArtifactRecord>
+
+  /**
+   * Return full metadata for an artifact, including computed fields
+   * (`pending_changes`, `size_bytes`).
+   */
+  inspect(id: ArtifactId): Promise<ArtifactMetadata>
+
+  /**
+   * List artifacts matching the query. Returns lightweight refs.
+   * Returns all artifacts if query is empty.
+   */
+  list(query?: ArtifactQuery): Promise<ArtifactRef[]>
+
+  /**
+   * Lock an artifact — transitions it to append-only.
+   * `write` and `edit` will fail on locked artifacts.
+   * Idempotent: locking an already-locked artifact is a no-op.
+   */
+  lock(id: ArtifactId): Promise<ArtifactRecord>
+}

--- a/src/artifact/filesystem.test.ts
+++ b/src/artifact/filesystem.test.ts
@@ -1,0 +1,333 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test"
+import { mkdtemp, rm, readdir } from "node:fs/promises"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { FilesystemArtifactAdapter } from "./filesystem.js"
+
+describe("FilesystemArtifactAdapter", () => {
+  let tmpDir: string
+  let adapter: FilesystemArtifactAdapter
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "spores-artifact-test-"))
+    adapter = new FilesystemArtifactAdapter(tmpDir)
+  })
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  // -------------------------------------------------------------------------
+  // create
+  // -------------------------------------------------------------------------
+
+  describe("create", () => {
+    it("returns a record with ULID id, version=1, locked=false", async () => {
+      const record = await adapter.create({
+        type: "brief",
+        title: "Q2 Launch Brief",
+        body: "# Q2 Launch\n\nContent here.",
+      })
+      expect(record.id).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/)
+      expect(record.type).toBe("brief")
+      expect(record.title).toBe("Q2 Launch Brief")
+      expect(record.version).toBe(1)
+      expect(record.locked).toBe(false)
+      expect(record.tags).toEqual([])
+      expect(record.created_at).toBe(record.updated_at)
+    })
+
+    it("stores tags and derived_from", async () => {
+      const source = await adapter.create({
+        type: "brief",
+        title: "Source",
+        body: "src",
+      })
+      const derived = await adapter.create({
+        type: "memo",
+        title: "Derived",
+        body: "derived content",
+        tags: ["important", "q2"],
+        derived_from: source.id,
+      })
+      expect(derived.tags).toEqual(["important", "q2"])
+      expect(derived.derived_from).toBe(source.id)
+    })
+
+    it("creates .spores/artifacts/<id>/meta.json and v1.md on disk", async () => {
+      const record = await adapter.create({
+        type: "note",
+        title: "Test",
+        body: "hello",
+      })
+      const entries = await readdir(join(tmpDir, ".spores", "artifacts", record.id))
+      expect(entries).toContain("meta.json")
+      expect(entries).toContain("v1.md")
+    })
+
+    it("generates monotonic ULIDs under rapid succession", async () => {
+      const ids: string[] = []
+      for (let i = 0; i < 30; i++) {
+        const r = await adapter.create({ type: "note", title: `n${i}`, body: `body ${i}` })
+        ids.push(r.id)
+      }
+      const sorted = [...ids].sort()
+      expect(ids).toEqual(sorted)
+      expect(new Set(ids).size).toBe(ids.length)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // read
+  // -------------------------------------------------------------------------
+
+  describe("read", () => {
+    it("returns the body content", async () => {
+      const body = "# Hello\n\nThis is the artifact body."
+      const record = await adapter.create({ type: "doc", title: "T", body })
+      const content = await adapter.read(record.id)
+      expect(content).toBe(body)
+    })
+
+    it("reads a specific version", async () => {
+      const record = await adapter.create({ type: "doc", title: "T", body: "v1 content" })
+      await adapter.write(record.id, { body: "v2 content", mode: "iterate" })
+      const v1 = await adapter.read(record.id, { version: 1 })
+      const v2 = await adapter.read(record.id, { version: 2 })
+      expect(v1).toBe("v1 content")
+      expect(v2).toBe("v2 content")
+    })
+
+    it("reads current version when version omitted", async () => {
+      const record = await adapter.create({ type: "doc", title: "T", body: "first" })
+      await adapter.write(record.id, { body: "second", mode: "iterate" })
+      const content = await adapter.read(record.id)
+      expect(content).toBe("second")
+    })
+
+    it("throws on missing id", async () => {
+      await expect(adapter.read("MISSING_ID")).rejects.toThrow(/not found/i)
+    })
+
+    it("throws on missing version", async () => {
+      const record = await adapter.create({ type: "doc", title: "T", body: "body" })
+      await expect(adapter.read(record.id, { version: 99 })).rejects.toThrow(
+        /not found/i,
+      )
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // write
+  // -------------------------------------------------------------------------
+
+  describe("write", () => {
+    describe("mode: iterate (default)", () => {
+      it("bumps version number", async () => {
+        const record = await adapter.create({ type: "doc", title: "T", body: "v1" })
+        const updated = await adapter.write(record.id, { body: "v2", mode: "iterate" })
+        expect(updated.version).toBe(2)
+        expect(updated.body_ref).toContain("v2.md")
+      })
+
+      it("prior version body is still accessible after iterate", async () => {
+        const record = await adapter.create({ type: "doc", title: "T", body: "first" })
+        await adapter.write(record.id, { body: "second", mode: "iterate" })
+        const v1 = await adapter.read(record.id, { version: 1 })
+        expect(v1).toBe("first")
+      })
+
+      it("defaults to iterate when mode omitted", async () => {
+        const record = await adapter.create({ type: "doc", title: "T", body: "v1" })
+        const updated = await adapter.write(record.id, { body: "v2" })
+        expect(updated.version).toBe(2)
+      })
+    })
+
+    describe("mode: replace", () => {
+      it("overwrites current version, version number unchanged", async () => {
+        const record = await adapter.create({ type: "doc", title: "T", body: "original" })
+        const updated = await adapter.write(record.id, { body: "replaced", mode: "replace" })
+        expect(updated.version).toBe(1)
+        const content = await adapter.read(record.id)
+        expect(content).toBe("replaced")
+      })
+    })
+
+    describe("mode: create", () => {
+      it("throws because artifact already exists", async () => {
+        const record = await adapter.create({ type: "doc", title: "T", body: "body" })
+        await expect(
+          adapter.write(record.id, { body: "body", mode: "create" }),
+        ).rejects.toThrow(/already exists/i)
+      })
+    })
+
+    it("throws on locked artifact", async () => {
+      const record = await adapter.create({ type: "doc", title: "T", body: "body" })
+      await adapter.lock(record.id)
+      await expect(
+        adapter.write(record.id, { body: "update" }),
+      ).rejects.toThrow(/locked/i)
+    })
+
+    it("throws on missing id", async () => {
+      await expect(
+        adapter.write("MISSING", { body: "x" }),
+      ).rejects.toThrow(/not found/i)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // edit
+  // -------------------------------------------------------------------------
+
+  describe("edit", () => {
+    it("replaces old string with new string and bumps version", async () => {
+      const record = await adapter.create({
+        type: "doc",
+        title: "T",
+        body: "Hello world, this is a test.",
+      })
+      const updated = await adapter.edit(record.id, "world", "SPORES")
+      expect(updated.version).toBe(2)
+      const content = await adapter.read(updated.id)
+      expect(content).toBe("Hello SPORES, this is a test.")
+    })
+
+    it("throws if old string not found", async () => {
+      const record = await adapter.create({ type: "doc", title: "T", body: "hello" })
+      await expect(
+        adapter.edit(record.id, "NOT_IN_BODY", "replacement"),
+      ).rejects.toThrow(/not found/i)
+    })
+
+    it("throws on locked artifact", async () => {
+      const record = await adapter.create({ type: "doc", title: "T", body: "content" })
+      await adapter.lock(record.id)
+      await expect(
+        adapter.edit(record.id, "content", "updated"),
+      ).rejects.toThrow(/locked/i)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // inspect
+  // -------------------------------------------------------------------------
+
+  describe("inspect", () => {
+    it("returns metadata with pending_changes=false and size_bytes", async () => {
+      const record = await adapter.create({
+        type: "note",
+        title: "Test Note",
+        body: "content here",
+      })
+      const meta = await adapter.inspect(record.id)
+      expect(meta.id).toBe(record.id)
+      expect(meta.type).toBe("note")
+      expect(meta.pending_changes).toBe(false)
+      expect(typeof meta.size_bytes).toBe("number")
+      expect((meta.size_bytes ?? 0) > 0).toBe(true)
+    })
+
+    it("throws on missing id", async () => {
+      await expect(adapter.inspect("MISSING")).rejects.toThrow(/not found/i)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // list
+  // -------------------------------------------------------------------------
+
+  describe("list", () => {
+    it("returns empty when no artifacts exist", async () => {
+      const refs = await adapter.list()
+      expect(refs).toEqual([])
+    })
+
+    it("returns all artifacts with empty query", async () => {
+      await adapter.create({ type: "brief", title: "A", body: "a" })
+      await adapter.create({ type: "memo", title: "B", body: "b" })
+      const refs = await adapter.list()
+      expect(refs.length).toBe(2)
+    })
+
+    it("filters by type", async () => {
+      await adapter.create({ type: "brief", title: "A", body: "a" })
+      await adapter.create({ type: "memo", title: "B", body: "b" })
+      const briefs = await adapter.list({ type: "brief" })
+      expect(briefs.length).toBe(1)
+      expect(briefs[0]!.type).toBe("brief")
+    })
+
+    it("filters by tags (any match)", async () => {
+      await adapter.create({ type: "note", title: "Tagged", body: "x", tags: ["q2", "launch"] })
+      await adapter.create({ type: "note", title: "Other", body: "y", tags: ["q1"] })
+      await adapter.create({ type: "note", title: "None", body: "z", tags: [] })
+
+      const q2 = await adapter.list({ tags: ["q2"] })
+      expect(q2.length).toBe(1)
+      expect(q2[0]!.title).toBe("Tagged")
+
+      const q2orQ1 = await adapter.list({ tags: ["q2", "q1"] })
+      expect(q2orQ1.length).toBe(2)
+    })
+
+    it("filters by locked=true", async () => {
+      const a = await adapter.create({ type: "doc", title: "A", body: "a" })
+      await adapter.create({ type: "doc", title: "B", body: "b" })
+      await adapter.lock(a.id)
+
+      const locked = await adapter.list({ locked: true })
+      expect(locked.length).toBe(1)
+      expect(locked[0]!.id).toBe(a.id)
+
+      const unlocked = await adapter.list({ locked: false })
+      expect(unlocked.length).toBe(1)
+      expect(unlocked[0]!.title).toBe("B")
+    })
+
+    it("returns lightweight refs (no body_ref)", async () => {
+      await adapter.create({ type: "note", title: "T", body: "body" })
+      const refs = await adapter.list()
+      expect(refs.length).toBe(1)
+      expect("body_ref" in refs[0]!).toBe(false)
+      expect(refs[0]!.id).toBeDefined()
+      expect(refs[0]!.type).toBeDefined()
+      expect(refs[0]!.title).toBeDefined()
+      expect(refs[0]!.version).toBeDefined()
+      expect(refs[0]!.locked).toBeDefined()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // lock
+  // -------------------------------------------------------------------------
+
+  describe("lock", () => {
+    it("sets locked=true", async () => {
+      const record = await adapter.create({ type: "doc", title: "T", body: "body" })
+      const locked = await adapter.lock(record.id)
+      expect(locked.locked).toBe(true)
+    })
+
+    it("persists the locked state", async () => {
+      const record = await adapter.create({ type: "doc", title: "T", body: "body" })
+      await adapter.lock(record.id)
+      const meta = await adapter.inspect(record.id)
+      expect(meta.locked).toBe(true)
+    })
+
+    it("is idempotent — locking an already-locked artifact returns current record", async () => {
+      const record = await adapter.create({ type: "doc", title: "T", body: "body" })
+      const first = await adapter.lock(record.id)
+      const second = await adapter.lock(record.id)
+      expect(second.locked).toBe(true)
+      expect(second.version).toBe(first.version)
+    })
+
+    it("throws on missing id", async () => {
+      await expect(adapter.lock("MISSING")).rejects.toThrow(/not found/i)
+    })
+  })
+})

--- a/src/artifact/filesystem.ts
+++ b/src/artifact/filesystem.ts
@@ -1,0 +1,384 @@
+import {
+  readdir,
+  readFile,
+  writeFile,
+  mkdir,
+  stat,
+} from "node:fs/promises"
+import { join } from "node:path"
+import type {
+  ArtifactId,
+  ArtifactMetadata,
+  ArtifactQuery,
+  ArtifactRecord,
+  ArtifactRef,
+} from "../types.js"
+import type {
+  ArtifactAdapter,
+  CreateArtifactInput,
+  WriteArtifactInput,
+} from "./adapter.js"
+
+interface NodeError extends Error {
+  code?: string | undefined
+}
+
+function isNodeError(err: unknown): err is NodeError {
+  return err instanceof Error
+}
+
+// ---------------------------------------------------------------------------
+// Minimal monotonic ULID generator (zero deps) — same as tasks/filesystem.ts
+// ---------------------------------------------------------------------------
+
+const ULID_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+const TIME_LEN = 10
+const RANDOM_LEN = 16
+
+function encodeTime(now: number, len: number): string {
+  let out = ""
+  for (let i = len - 1; i >= 0; i--) {
+    const mod = now % 32
+    out = ULID_ALPHABET[mod]! + out
+    now = (now - mod) / 32
+  }
+  return out
+}
+
+function randomChars(len: number): string {
+  const bytes = new Uint8Array(len)
+  crypto.getRandomValues(bytes)
+  let out = ""
+  for (let i = 0; i < len; i++) {
+    out += ULID_ALPHABET[bytes[i]! % 32]
+  }
+  return out
+}
+
+function incrementBase32(s: string): string {
+  const chars = s.split("")
+  for (let i = chars.length - 1; i >= 0; i--) {
+    const idx = ULID_ALPHABET.indexOf(chars[i]!)
+    if (idx < 31) {
+      chars[i] = ULID_ALPHABET[idx + 1]!
+      return chars.join("")
+    }
+    chars[i] = "0"
+  }
+  return randomChars(chars.length)
+}
+
+function createUlidFactory(): () => string {
+  let lastTime = 0
+  let lastRandom = ""
+  return function ulid(): string {
+    const now = Date.now()
+    if (now === lastTime) {
+      lastRandom = incrementBase32(lastRandom)
+    } else {
+      lastTime = now
+      lastRandom = randomChars(RANDOM_LEN)
+    }
+    return encodeTime(now, TIME_LEN) + lastRandom
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function bodyToString(body: string | ReadableStream): Promise<string> {
+  if (typeof body === "string") return body
+  return new Response(body).text()
+}
+
+// ---------------------------------------------------------------------------
+// FilesystemArtifactAdapter
+//
+// On-disk layout (project-level):
+//   .spores/artifacts/<id>/meta.json     — ArtifactRecord (minus pending_changes)
+//   .spores/artifacts/<id>/v1.md         — body at version 1
+//   .spores/artifacts/<id>/v2.md         — body at version 2 (after iterate write)
+//   ...
+//
+// body_ref in ArtifactRecord is the relative path within the artifacts dir:
+//   "<id>/v<n>.md"
+//
+// Global resolution: project-level wins over user-level (.spores in $HOME).
+// The adapter is constructed with a single baseDir for now. Layered project/
+// global resolution follows the same pattern as other primitives.
+// ---------------------------------------------------------------------------
+
+export class FilesystemArtifactAdapter implements ArtifactAdapter {
+  private dir: string
+  private ulid: () => string
+
+  constructor(baseDir: string) {
+    this.dir = join(baseDir, ".spores", "artifacts")
+    this.ulid = createUlidFactory()
+  }
+
+  // -------------------------------------------------------------------------
+  // create
+  // -------------------------------------------------------------------------
+
+  async create(input: CreateArtifactInput): Promise<ArtifactRecord> {
+    const id: ArtifactId = this.ulid()
+    const now = new Date().toISOString()
+    const bodyContent = await bodyToString(input.body)
+    const bodyRef = `${id}/v1.md`
+
+    const record: ArtifactRecord = {
+      id,
+      type: input.type,
+      title: input.title,
+      body_ref: bodyRef,
+      version: 1,
+      locked: false,
+      tags: input.tags ?? [],
+      created_at: now,
+      updated_at: now,
+      ...(input.derived_from !== undefined ? { derived_from: input.derived_from } : {}),
+    }
+
+    const artifactDir = join(this.dir, id)
+    await mkdir(artifactDir, { recursive: true })
+    await writeFile(join(this.dir, bodyRef), bodyContent, "utf-8")
+    await this.writeMeta(record)
+
+    return record
+  }
+
+  // -------------------------------------------------------------------------
+  // read
+  // -------------------------------------------------------------------------
+
+  async read(
+    id: ArtifactId,
+    opts?: { version?: number | undefined },
+  ): Promise<string> {
+    const record = await this.loadMeta(id)
+
+    const version = opts?.version ?? record.version
+    const bodyPath = join(this.dir, `${id}/v${version}.md`)
+
+    try {
+      return await readFile(bodyPath, "utf-8")
+    } catch (err) {
+      if (isNodeError(err) && err.code === "ENOENT") {
+        throw new Error(
+          `Artifact ${id} version ${version} not found`,
+        )
+      }
+      throw err
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // write
+  // -------------------------------------------------------------------------
+
+  async write(
+    id: ArtifactId,
+    input: WriteArtifactInput,
+  ): Promise<ArtifactRecord> {
+    const record = await this.loadMeta(id)
+    const mode = input.mode ?? "iterate"
+
+    if (record.locked && mode !== "create") {
+      throw new Error(`Artifact ${id} is locked and cannot be written`)
+    }
+
+    if (mode === "create") {
+      throw new Error(
+        `Artifact ${id} already exists (mode "create" requires a new id)`,
+      )
+    }
+
+    const bodyContent = await bodyToString(input.body)
+    const now = new Date().toISOString()
+
+    let newVersion: number
+    if (mode === "iterate") {
+      newVersion = record.version + 1
+    } else {
+      // replace — overwrite in place
+      newVersion = record.version
+    }
+
+    const bodyRef = `${id}/v${newVersion}.md`
+    await writeFile(join(this.dir, bodyRef), bodyContent, "utf-8")
+
+    const updated: ArtifactRecord = {
+      ...record,
+      version: newVersion,
+      body_ref: bodyRef,
+      updated_at: now,
+    }
+    await this.writeMeta(updated)
+    return updated
+  }
+
+  // -------------------------------------------------------------------------
+  // edit
+  // -------------------------------------------------------------------------
+
+  async edit(
+    id: ArtifactId,
+    oldStr: string,
+    newStr: string,
+  ): Promise<ArtifactRecord> {
+    const record = await this.loadMeta(id)
+
+    if (record.locked) {
+      throw new Error(`Artifact ${id} is locked and cannot be edited`)
+    }
+
+    const body = await this.read(id)
+
+    if (!body.includes(oldStr)) {
+      throw new Error(
+        `edit: old string not found in artifact ${id}`,
+      )
+    }
+
+    const newBody = body.replace(oldStr, newStr)
+    return this.write(id, { body: newBody, mode: "iterate" })
+  }
+
+  // -------------------------------------------------------------------------
+  // inspect
+  // -------------------------------------------------------------------------
+
+  async inspect(id: ArtifactId): Promise<ArtifactMetadata> {
+    const record = await this.loadMeta(id)
+    const bodyPath = join(this.dir, record.body_ref)
+
+    let size_bytes: number | undefined
+    try {
+      const s = await stat(bodyPath)
+      size_bytes = s.size
+    } catch {
+      // size is optional; don't fail inspect if body file is missing
+    }
+
+    return {
+      ...record,
+      pending_changes: false, // filesystem adapter: no draft/staging concept
+      size_bytes,
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // list
+  // -------------------------------------------------------------------------
+
+  async list(query?: ArtifactQuery): Promise<ArtifactRef[]> {
+    let entries: string[]
+    try {
+      entries = await readdir(this.dir)
+    } catch (err) {
+      if (isNodeError(err) && err.code === "ENOENT") return []
+      throw err
+    }
+
+    const refs: ArtifactRef[] = []
+    for (const entry of entries) {
+      const metaPath = join(this.dir, entry, "meta.json")
+      try {
+        const data = await readFile(metaPath, "utf-8")
+        const record = JSON.parse(data) as ArtifactRecord
+
+        if (!matchesQuery(record, query)) continue
+
+        refs.push({
+          id: record.id,
+          type: record.type,
+          title: record.title,
+          version: record.version,
+          locked: record.locked,
+          tags: record.tags,
+          updated_at: record.updated_at,
+        })
+      } catch (err) {
+        if (isNodeError(err) && err.code === "ENOENT") continue
+        const msg = err instanceof Error ? err.message : String(err)
+        process.stderr.write(
+          `warning: skipping malformed artifact directory ${entry}: ${msg}\n`,
+        )
+      }
+    }
+
+    // Sort by updated_at descending (newest first)
+    refs.sort((a, b) =>
+      a.updated_at < b.updated_at ? 1 : a.updated_at > b.updated_at ? -1 : 0,
+    )
+    return refs
+  }
+
+  // -------------------------------------------------------------------------
+  // lock
+  // -------------------------------------------------------------------------
+
+  async lock(id: ArtifactId): Promise<ArtifactRecord> {
+    const record = await this.loadMeta(id)
+
+    if (record.locked) {
+      // Idempotent — already locked
+      return record
+    }
+
+    const updated: ArtifactRecord = {
+      ...record,
+      locked: true,
+      updated_at: new Date().toISOString(),
+    }
+    await this.writeMeta(updated)
+    return updated
+  }
+
+  // -------------------------------------------------------------------------
+  // internals
+  // -------------------------------------------------------------------------
+
+  private async loadMeta(id: ArtifactId): Promise<ArtifactRecord> {
+    const metaPath = join(this.dir, id, "meta.json")
+    try {
+      const data = await readFile(metaPath, "utf-8")
+      return JSON.parse(data) as ArtifactRecord
+    } catch (err) {
+      if (isNodeError(err) && err.code === "ENOENT") {
+        throw new Error(`Artifact not found: ${id}`)
+      }
+      throw err
+    }
+  }
+
+  private async writeMeta(record: ArtifactRecord): Promise<void> {
+    const artifactDir = join(this.dir, record.id)
+    await mkdir(artifactDir, { recursive: true })
+    await writeFile(
+      join(artifactDir, "meta.json"),
+      JSON.stringify(record, null, 2),
+      "utf-8",
+    )
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Query matching helper
+// ---------------------------------------------------------------------------
+
+function matchesQuery(
+  record: ArtifactRecord,
+  query: ArtifactQuery | undefined,
+): boolean {
+  if (query === undefined) return true
+  if (query.type !== undefined && record.type !== query.type) return false
+  if (query.locked !== undefined && record.locked !== query.locked) return false
+  if (query.tags !== undefined && query.tags.length > 0) {
+    const hasAny = query.tags.some((t) => record.tags.includes(t))
+    if (!hasAny) return false
+  }
+  return true
+}

--- a/src/cli/commands/artifact.test.ts
+++ b/src/cli/commands/artifact.test.ts
@@ -1,0 +1,377 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test"
+import { mkdtemp, rm, mkdir, writeFile, chmod } from "node:fs/promises"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import {
+  artifactCreateCommand,
+  artifactReadCommand,
+  artifactWriteCommand,
+  artifactEditCommand,
+  artifactInspectCommand,
+  artifactListCommand,
+  artifactLockCommand,
+} from "./artifact.js"
+import { FilesystemArtifactAdapter } from "../../artifact/filesystem.js"
+import { FilesystemAdapter } from "../../memory/filesystem.js"
+import type { Ctx } from "../main.js"
+import type { SporesConfig } from "../../types.js"
+
+function makeCtx(baseDir: string, json = true): Ctx {
+  const config: SporesConfig = {
+    adapter: "filesystem",
+    memory: { dir: ".spores/memory", defaultTier: "L1", dreamDepth: 1 },
+    workflow: {
+      graphsDir: ".spores/workflow/graphs",
+      runsDir: ".spores/workflow/runs",
+    },
+    wake: {},
+  }
+  return {
+    adapter: new FilesystemAdapter(baseDir),
+    config,
+    baseDir,
+    json,
+    wide: false,
+  }
+}
+
+function captureStdout(fn: () => Promise<void>): Promise<string> {
+  const origLog = console.log
+  let captured = ""
+  console.log = (...args: unknown[]) => {
+    captured +=
+      args.map((a) => (typeof a === "string" ? a : String(a))).join(" ") + "\n"
+  }
+  return fn()
+    .then(() => captured)
+    .finally(() => {
+      console.log = origLog
+    })
+}
+
+function captureStdoutWrite(fn: () => Promise<void>): Promise<string> {
+  const orig = process.stdout.write.bind(process.stdout)
+  let captured = ""
+  process.stdout.write = (s: unknown) => {
+    captured += String(s)
+    return true
+  }
+  return fn()
+    .then(() => captured)
+    .finally(() => {
+      process.stdout.write = orig
+    })
+}
+
+describe("artifact CLI commands", () => {
+  let tmpDir: string
+  let ctx: Ctx
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "spores-artifact-cli-"))
+    ctx = makeCtx(tmpDir)
+  })
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  // -------------------------------------------------------------------------
+  // artifact create
+  // -------------------------------------------------------------------------
+
+  describe("artifact create", () => {
+    it("creates an artifact and returns the record", async () => {
+      const out = await captureStdout(() =>
+        artifactCreateCommand(ctx, ["brief", "Q2 Launch summary"], {
+          title: "Q2 Launch Brief",
+          tags: "q2,launch",
+        }),
+      )
+      const result = JSON.parse(out)
+      const record = result.artifact
+      expect(record.type).toBe("brief")
+      expect(record.title).toBe("Q2 Launch Brief")
+      expect(record.version).toBe(1)
+      expect(record.locked).toBe(false)
+      expect(record.tags).toEqual(["q2", "launch"])
+      expect(record.id).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/)
+      expect(result.hook).toBeUndefined()
+    })
+
+    it("uses type as title when --title is omitted", async () => {
+      const out = await captureStdout(() =>
+        artifactCreateCommand(ctx, ["memo", "body content"], {}),
+      )
+      const result = JSON.parse(out)
+      expect(result.artifact.title).toBe("memo")
+    })
+
+    it("persists artifact to disk", async () => {
+      const out = await captureStdout(() =>
+        artifactCreateCommand(ctx, ["note", "hello world"], { title: "My Note" }),
+      )
+      const result = JSON.parse(out)
+      const id = result.artifact.id
+
+      const adapter = new FilesystemArtifactAdapter(tmpDir)
+      const body = await adapter.read(id)
+      expect(body).toBe("hello world")
+    })
+
+    it("throws on missing type argument", async () => {
+      await expect(artifactCreateCommand(ctx, [], {})).rejects.toThrow(/usage/i)
+    })
+
+    it("fires artifact.created hook when script exists", async () => {
+      const hooksDir = join(tmpDir, ".spores", "hooks")
+      await mkdir(hooksDir, { recursive: true })
+      const hookScript = join(hooksDir, "artifact.created")
+      await writeFile(
+        hookScript,
+        `#!/usr/bin/env sh\necho "hook ran: $SPORES_ARTIFACT_ID"`,
+      )
+      await chmod(hookScript, 0o755)
+
+      const out = await captureStdout(() =>
+        artifactCreateCommand(ctx, ["brief", "body"], { title: "Hook Test" }),
+      )
+      const result = JSON.parse(out)
+      expect(result.hook).toBeDefined()
+      expect(result.hook.ran).toBe(true)
+      expect(result.hook.stdout).toContain("hook ran:")
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // artifact read
+  // -------------------------------------------------------------------------
+
+  describe("artifact read", () => {
+    it("outputs raw body to stdout (non-json mode)", async () => {
+      const ctxHuman = makeCtx(tmpDir, false)
+      const adapter = new FilesystemArtifactAdapter(tmpDir)
+      const record = await adapter.create({ type: "doc", title: "T", body: "# Hello\n\nWorld." })
+
+      const out = await captureStdoutWrite(() =>
+        artifactReadCommand(ctxHuman, [record.id], {}),
+      )
+      expect(out).toContain("# Hello")
+      expect(out).toContain("World.")
+    })
+
+    it("returns JSON body in --json mode", async () => {
+      const adapter = new FilesystemArtifactAdapter(tmpDir)
+      const record = await adapter.create({ type: "doc", title: "T", body: "content" })
+
+      const out = await captureStdout(() =>
+        artifactReadCommand(ctx, [record.id], {}),
+      )
+      const result = JSON.parse(out)
+      expect(result.id).toBe(record.id)
+      expect(result.body).toBe("content")
+    })
+
+    it("reads a specific version", async () => {
+      const adapter = new FilesystemArtifactAdapter(tmpDir)
+      const record = await adapter.create({ type: "doc", title: "T", body: "v1" })
+      await adapter.write(record.id, { body: "v2", mode: "iterate" })
+
+      const out = await captureStdout(() =>
+        artifactReadCommand(ctx, [record.id], { version: "1" }),
+      )
+      const result = JSON.parse(out)
+      expect(result.body).toBe("v1")
+    })
+
+    it("throws on missing id argument", async () => {
+      await expect(artifactReadCommand(ctx, [], {})).rejects.toThrow(/usage/i)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // artifact write
+  // -------------------------------------------------------------------------
+
+  describe("artifact write", () => {
+    it("writes new content and bumps version (iterate)", async () => {
+      const adapter = new FilesystemArtifactAdapter(tmpDir)
+      const record = await adapter.create({ type: "doc", title: "T", body: "v1" })
+
+      const out = await captureStdout(() =>
+        artifactWriteCommand(ctx, [record.id, "v2 content"], { mode: "iterate" }),
+      )
+      const result = JSON.parse(out)
+      expect(result.artifact.version).toBe(2)
+    })
+
+    it("replaces content in place (replace mode)", async () => {
+      const adapter = new FilesystemArtifactAdapter(tmpDir)
+      const record = await adapter.create({ type: "doc", title: "T", body: "original" })
+
+      const out = await captureStdout(() =>
+        artifactWriteCommand(ctx, [record.id, "replaced"], { mode: "replace" }),
+      )
+      const result = JSON.parse(out)
+      expect(result.artifact.version).toBe(1)
+      const body = await adapter.read(record.id)
+      expect(body).toBe("replaced")
+    })
+
+    it("throws on missing id", async () => {
+      await expect(artifactWriteCommand(ctx, [], {})).rejects.toThrow(/usage/i)
+    })
+
+    it("throws on invalid mode", async () => {
+      const adapter = new FilesystemArtifactAdapter(tmpDir)
+      const record = await adapter.create({ type: "doc", title: "T", body: "x" })
+      await expect(
+        artifactWriteCommand(ctx, [record.id, "body"], { mode: "badmode" }),
+      ).rejects.toThrow(/invalid mode/i)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // artifact edit
+  // -------------------------------------------------------------------------
+
+  describe("artifact edit", () => {
+    it("replaces old string with new and bumps version", async () => {
+      const adapter = new FilesystemArtifactAdapter(tmpDir)
+      const record = await adapter.create({
+        type: "doc",
+        title: "T",
+        body: "Hello world.",
+      })
+
+      const out = await captureStdout(() =>
+        artifactEditCommand(ctx, [record.id], { old: "world", new: "SPORES" }),
+      )
+      const result = JSON.parse(out)
+      expect(result.artifact.version).toBe(2)
+
+      const body = await adapter.read(record.id)
+      expect(body).toBe("Hello SPORES.")
+    })
+
+    it("throws on missing --old or --new flags", async () => {
+      const adapter = new FilesystemArtifactAdapter(tmpDir)
+      const record = await adapter.create({ type: "doc", title: "T", body: "x" })
+      await expect(
+        artifactEditCommand(ctx, [record.id], { old: "x" }),
+      ).rejects.toThrow(/usage/i)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // artifact inspect
+  // -------------------------------------------------------------------------
+
+  describe("artifact inspect", () => {
+    it("returns metadata with pending_changes and size_bytes", async () => {
+      const adapter = new FilesystemArtifactAdapter(tmpDir)
+      const record = await adapter.create({ type: "note", title: "My Note", body: "content" })
+
+      const out = await captureStdout(() =>
+        artifactInspectCommand(ctx, [record.id], {}),
+      )
+      const result = JSON.parse(out)
+      const meta = result.artifact
+      expect(meta.id).toBe(record.id)
+      expect(meta.type).toBe("note")
+      expect(meta.pending_changes).toBe(false)
+      expect(typeof meta.size_bytes).toBe("number")
+    })
+
+    it("throws on missing id", async () => {
+      await expect(artifactInspectCommand(ctx, [], {})).rejects.toThrow(/usage/i)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // artifact list
+  // -------------------------------------------------------------------------
+
+  describe("artifact list", () => {
+    it("returns empty array when no artifacts", async () => {
+      const out = await captureStdout(() => artifactListCommand(ctx, [], {}))
+      const result = JSON.parse(out)
+      expect(result).toEqual([])
+    })
+
+    it("returns all artifacts", async () => {
+      const adapter = new FilesystemArtifactAdapter(tmpDir)
+      await adapter.create({ type: "brief", title: "A", body: "a" })
+      await adapter.create({ type: "memo", title: "B", body: "b" })
+
+      const out = await captureStdout(() => artifactListCommand(ctx, [], {}))
+      const refs = JSON.parse(out)
+      expect(refs.length).toBe(2)
+    })
+
+    it("filters by type", async () => {
+      const adapter = new FilesystemArtifactAdapter(tmpDir)
+      await adapter.create({ type: "brief", title: "A", body: "a" })
+      await adapter.create({ type: "memo", title: "B", body: "b" })
+
+      const out = await captureStdout(() =>
+        artifactListCommand(ctx, [], { type: "brief" }),
+      )
+      const refs = JSON.parse(out)
+      expect(refs.length).toBe(1)
+      expect(refs[0].type).toBe("brief")
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // artifact lock
+  // -------------------------------------------------------------------------
+
+  describe("artifact lock", () => {
+    it("locks the artifact", async () => {
+      const adapter = new FilesystemArtifactAdapter(tmpDir)
+      const record = await adapter.create({ type: "doc", title: "T", body: "body" })
+
+      const out = await captureStdout(() =>
+        artifactLockCommand(ctx, [record.id], {}),
+      )
+      const result = JSON.parse(out)
+      expect(result.artifact.locked).toBe(true)
+    })
+
+    it("persists locked state", async () => {
+      const adapter = new FilesystemArtifactAdapter(tmpDir)
+      const record = await adapter.create({ type: "doc", title: "T", body: "body" })
+      await artifactLockCommand(ctx, [record.id], {})
+
+      const meta = await adapter.inspect(record.id)
+      expect(meta.locked).toBe(true)
+    })
+
+    it("throws on missing id", async () => {
+      await expect(artifactLockCommand(ctx, [], {})).rejects.toThrow(/usage/i)
+    })
+
+    it("fires artifact.locked hook when script exists", async () => {
+      const adapter = new FilesystemArtifactAdapter(tmpDir)
+      const record = await adapter.create({ type: "doc", title: "T", body: "body" })
+
+      const hooksDir = join(tmpDir, ".spores", "hooks")
+      await mkdir(hooksDir, { recursive: true })
+      const hookScript = join(hooksDir, "artifact.locked")
+      await writeFile(
+        hookScript,
+        `#!/usr/bin/env sh\necho "locked: $SPORES_ARTIFACT_ID v$SPORES_ARTIFACT_FINAL_VERSION"`,
+      )
+      await chmod(hookScript, 0o755)
+
+      const out = await captureStdout(() =>
+        artifactLockCommand(ctx, [record.id], {}),
+      )
+      const result = JSON.parse(out)
+      expect(result.hook).toBeDefined()
+      expect(result.hook.ran).toBe(true)
+      expect(result.hook.stdout).toContain("locked:")
+    })
+  })
+})

--- a/src/cli/commands/artifact.ts
+++ b/src/cli/commands/artifact.ts
@@ -1,0 +1,279 @@
+import type {
+  ArtifactCreatedOutput,
+  ArtifactWrittenOutput,
+  ArtifactEditedOutput,
+  ArtifactLockedOutput,
+  ArtifactInspectedOutput,
+  ArtifactRef,
+  HookInvocation,
+} from "../../types.js"
+import { FilesystemArtifactAdapter } from "../../artifact/filesystem.js"
+import { fireHook } from "../../hooks/fire.js"
+import type { Command } from "../context.js"
+import { output } from "../output.js"
+import {
+  formatArtifactCreated,
+  formatArtifactWritten,
+  formatArtifactEdited,
+  formatArtifactLocked,
+  formatArtifactInspected,
+  formatArtifactList,
+} from "../format.js"
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+function emitHookWarning(event: string, hook: HookInvocation): void {
+  if (!hook.ran) return
+  if (hook.stderr.length > 0) process.stderr.write(hook.stderr)
+  if (hook.error !== undefined) {
+    process.stderr.write(`[hook warning] ${event}: ${hook.error}\n`)
+  } else if (hook.exit_code !== null && hook.exit_code !== 0) {
+    process.stderr.write(`[hook warning] ${event} exited ${hook.exit_code}\n`)
+  }
+}
+
+function parseTags(flags: Record<string, string | true>): string[] {
+  if (typeof flags["tags"] === "string") {
+    return flags["tags"]
+      .split(",")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0)
+  }
+  return []
+}
+
+async function readBodyFromFlags(
+  args: string[],
+  flags: Record<string, string | true>,
+): Promise<string> {
+  // Body priority: --from file, then positional arg, then stdin
+  if (typeof flags["from"] === "string") {
+    const { readFile } = await import("node:fs/promises")
+    return readFile(flags["from"], "utf-8")
+  }
+  const positional = args[0]
+  if (positional !== undefined) return positional
+  // Read from stdin
+  return new Response(Bun.stdin.stream()).text()
+}
+
+// ---------------------------------------------------------------------------
+// artifact create
+// ---------------------------------------------------------------------------
+
+export const artifactCreateCommand: Command = async (ctx, args, flags) => {
+  const type = args[0]
+  if (type === undefined) {
+    throw new Error(
+      "Usage: spores artifact create <type> [--title T] [--from FILE | body]",
+    )
+  }
+
+  const title =
+    typeof flags["title"] === "string" ? flags["title"] : type
+  const tags = parseTags(flags)
+  const derivedFrom =
+    typeof flags["derived-from"] === "string"
+      ? flags["derived-from"]
+      : undefined
+
+  const bodyArgs = args.slice(1)
+  const body = await readBodyFromFlags(bodyArgs, flags)
+
+  const adapter = new FilesystemArtifactAdapter(ctx.baseDir)
+  const record = await adapter.create({ type, title, body, tags, derived_from: derivedFrom })
+
+  const hook = await fireHook(
+    "artifact.created",
+    {
+      SPORES_ARTIFACT_ID: record.id,
+      SPORES_ARTIFACT_TYPE: record.type,
+      SPORES_ARTIFACT_TITLE: record.title,
+      SPORES_ARTIFACT_TAGS: record.tags.join(","),
+    },
+    ctx.baseDir,
+  )
+
+  const result: ArtifactCreatedOutput = {
+    artifact: record,
+    hook: hook.ran ? hook : undefined,
+  }
+  output(ctx, result, formatArtifactCreated)
+  emitHookWarning("artifact.created", hook)
+}
+
+// ---------------------------------------------------------------------------
+// artifact read
+// ---------------------------------------------------------------------------
+
+export const artifactReadCommand: Command = async (ctx, args, flags) => {
+  const id = args[0]
+  if (id === undefined) {
+    throw new Error("Usage: spores artifact read <id> [--version N]")
+  }
+
+  const version =
+    typeof flags["version"] === "string"
+      ? parseInt(flags["version"], 10)
+      : undefined
+
+  const adapter = new FilesystemArtifactAdapter(ctx.baseDir)
+  const body = await adapter.read(id, { version })
+
+  // artifact read is pipe-friendly: always outputs raw body (no JSON wrapper)
+  // --json flag is silently honored by printing JSON if explicitly set
+  if (ctx.json) {
+    console.log(JSON.stringify({ id, version: version ?? "current", body }, null, 2))
+  } else {
+    process.stdout.write(body)
+    // Add trailing newline if content doesn't end with one
+    if (!body.endsWith("\n")) process.stdout.write("\n")
+  }
+}
+
+// ---------------------------------------------------------------------------
+// artifact write
+// ---------------------------------------------------------------------------
+
+export const artifactWriteCommand: Command = async (ctx, args, flags) => {
+  const id = args[0]
+  if (id === undefined) {
+    throw new Error(
+      "Usage: spores artifact write <id> [--from FILE | body] [--mode iterate|replace]",
+    )
+  }
+
+  const rawMode = typeof flags["mode"] === "string" ? flags["mode"] : "iterate"
+  if (rawMode !== "iterate" && rawMode !== "replace") {
+    throw new Error(`Invalid mode "${rawMode}". Must be iterate or replace.`)
+  }
+  const mode = rawMode as "iterate" | "replace"
+
+  const bodyArgs = args.slice(1)
+  const body = await readBodyFromFlags(bodyArgs, flags)
+
+  const adapter = new FilesystemArtifactAdapter(ctx.baseDir)
+  const record = await adapter.write(id, { body, mode })
+
+  const hook = await fireHook(
+    "artifact.written",
+    {
+      SPORES_ARTIFACT_ID: record.id,
+      SPORES_ARTIFACT_VERSION: String(record.version),
+      SPORES_ARTIFACT_MODE: mode,
+    },
+    ctx.baseDir,
+  )
+
+  const result: ArtifactWrittenOutput = {
+    artifact: record,
+    hook: hook.ran ? hook : undefined,
+  }
+  output(ctx, result, formatArtifactWritten)
+  emitHookWarning("artifact.written", hook)
+}
+
+// ---------------------------------------------------------------------------
+// artifact edit
+// ---------------------------------------------------------------------------
+
+export const artifactEditCommand: Command = async (ctx, args, flags) => {
+  const id = args[0]
+  const oldStr = typeof flags["old"] === "string" ? flags["old"] : undefined
+  const newStr = typeof flags["new"] === "string" ? flags["new"] : undefined
+
+  if (id === undefined || oldStr === undefined || newStr === undefined) {
+    throw new Error(
+      'Usage: spores artifact edit <id> --old "..." --new "..."',
+    )
+  }
+
+  const adapter = new FilesystemArtifactAdapter(ctx.baseDir)
+  const record = await adapter.edit(id, oldStr, newStr)
+
+  const hook = await fireHook(
+    "artifact.edited",
+    {
+      SPORES_ARTIFACT_ID: record.id,
+      SPORES_ARTIFACT_VERSION: String(record.version),
+    },
+    ctx.baseDir,
+  )
+
+  const result: ArtifactEditedOutput = {
+    artifact: record,
+    hook: hook.ran ? hook : undefined,
+  }
+  output(ctx, result, formatArtifactEdited)
+  emitHookWarning("artifact.edited", hook)
+}
+
+// ---------------------------------------------------------------------------
+// artifact inspect
+// ---------------------------------------------------------------------------
+
+export const artifactInspectCommand: Command = async (ctx, args, _flags) => {
+  const id = args[0]
+  if (id === undefined) {
+    throw new Error("Usage: spores artifact inspect <id>")
+  }
+
+  const adapter = new FilesystemArtifactAdapter(ctx.baseDir)
+  const meta = await adapter.inspect(id)
+
+  const result: ArtifactInspectedOutput = { artifact: meta }
+  output(ctx, result, formatArtifactInspected)
+}
+
+// ---------------------------------------------------------------------------
+// artifact list
+// ---------------------------------------------------------------------------
+
+export const artifactListCommand: Command = async (ctx, _args, flags) => {
+  const type =
+    typeof flags["type"] === "string" ? flags["type"] : undefined
+  const tags =
+    typeof flags["tags"] === "string"
+      ? flags["tags"].split(",").map((s) => s.trim())
+      : undefined
+  const lockedFlag = flags["locked"]
+  const locked =
+    lockedFlag === true ? true : lockedFlag === "false" ? false : undefined
+
+  const adapter = new FilesystemArtifactAdapter(ctx.baseDir)
+  const refs: ArtifactRef[] = await adapter.list({ type, tags, locked })
+
+  output(ctx, refs, formatArtifactList)
+}
+
+// ---------------------------------------------------------------------------
+// artifact lock
+// ---------------------------------------------------------------------------
+
+export const artifactLockCommand: Command = async (ctx, args, _flags) => {
+  const id = args[0]
+  if (id === undefined) {
+    throw new Error("Usage: spores artifact lock <id>")
+  }
+
+  const adapter = new FilesystemArtifactAdapter(ctx.baseDir)
+  const record = await adapter.lock(id)
+
+  const hook = await fireHook(
+    "artifact.locked",
+    {
+      SPORES_ARTIFACT_ID: record.id,
+      SPORES_ARTIFACT_FINAL_VERSION: String(record.version),
+    },
+    ctx.baseDir,
+  )
+
+  const result: ArtifactLockedOutput = {
+    artifact: record,
+    hook: hook.ran ? hook : undefined,
+  }
+  output(ctx, result, formatArtifactLocked)
+  emitHookWarning("artifact.locked", hook)
+}

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -27,6 +27,14 @@ import type {
   PersonaFile,
   PersonaRef,
   WakeOutput,
+  ArtifactRecord,
+  ArtifactMetadata,
+  ArtifactRef,
+  ArtifactCreatedOutput,
+  ArtifactWrittenOutput,
+  ArtifactEditedOutput,
+  ArtifactLockedOutput,
+  ArtifactInspectedOutput,
 } from "../types.js"
 
 
@@ -423,4 +431,102 @@ export function formatWake(result: WakeOutput): string {
     parts.push(hook.stdout.trimEnd())
   }
   return parts.join("\n")
+}
+
+// ---------------------------------------------------------------------------
+// Artifact formatters
+// ---------------------------------------------------------------------------
+
+export function formatArtifactRecord(r: ArtifactRecord): string {
+  const tags = r.tags.length > 0 ? ` [${r.tags.join(", ")}]` : ""
+  const locked = r.locked ? " (locked)" : ""
+  const derived = r.derived_from !== undefined ? `\n  derived_from: ${r.derived_from}` : ""
+  return [
+    `${r.id}${locked}`,
+    `  type:    ${r.type}`,
+    `  title:   ${r.title}${tags}`,
+    `  version: ${r.version}`,
+    `  updated: ${r.updated_at}${derived}`,
+  ].join("\n")
+}
+
+export function formatArtifactMetadata(m: ArtifactMetadata): string {
+  const tags = m.tags.length > 0 ? ` [${m.tags.join(", ")}]` : ""
+  const locked = m.locked ? " (locked)" : ""
+  const size =
+    m.size_bytes !== undefined ? `\n  size:    ${m.size_bytes} bytes` : ""
+  const derived = m.derived_from !== undefined ? `\n  derived_from: ${m.derived_from}` : ""
+  return [
+    `${m.id}${locked}`,
+    `  type:     ${m.type}`,
+    `  title:    ${m.title}${tags}`,
+    `  version:  ${m.version}`,
+    `  body_ref: ${m.body_ref}`,
+    `  created:  ${m.created_at}`,
+    `  updated:  ${m.updated_at}${size}${derived}`,
+  ].join("\n")
+}
+
+/** Human formatter for `artifact create`. */
+export function formatArtifactCreated(result: ArtifactCreatedOutput): string {
+  const parts = [`Artifact created:\n${formatArtifactRecord(result.artifact)}`]
+  const hook = result.hook
+  if (hook !== undefined && hook.ran && hook.stdout.trim().length > 0) {
+    parts.push("\n---\n")
+    parts.push(hook.stdout.trimEnd())
+  }
+  return parts.join("\n")
+}
+
+/** Human formatter for `artifact write`. */
+export function formatArtifactWritten(result: ArtifactWrittenOutput): string {
+  const parts = [`Artifact written:\n${formatArtifactRecord(result.artifact)}`]
+  const hook = result.hook
+  if (hook !== undefined && hook.ran && hook.stdout.trim().length > 0) {
+    parts.push("\n---\n")
+    parts.push(hook.stdout.trimEnd())
+  }
+  return parts.join("\n")
+}
+
+/** Human formatter for `artifact edit`. */
+export function formatArtifactEdited(result: ArtifactEditedOutput): string {
+  const parts = [`Artifact edited:\n${formatArtifactRecord(result.artifact)}`]
+  const hook = result.hook
+  if (hook !== undefined && hook.ran && hook.stdout.trim().length > 0) {
+    parts.push("\n---\n")
+    parts.push(hook.stdout.trimEnd())
+  }
+  return parts.join("\n")
+}
+
+/** Human formatter for `artifact lock`. */
+export function formatArtifactLocked(result: ArtifactLockedOutput): string {
+  const parts = [`Artifact locked:\n${formatArtifactRecord(result.artifact)}`]
+  const hook = result.hook
+  if (hook !== undefined && hook.ran && hook.stdout.trim().length > 0) {
+    parts.push("\n---\n")
+    parts.push(hook.stdout.trimEnd())
+  }
+  return parts.join("\n")
+}
+
+/** Human formatter for `artifact inspect`. */
+export function formatArtifactInspected(result: ArtifactInspectedOutput): string {
+  return formatArtifactMetadata(result.artifact)
+}
+
+/** Human formatter for `artifact list`. */
+export function formatArtifactList(refs: ArtifactRef[]): string {
+  if (refs.length === 0) return "No artifacts found."
+  return table(
+    ["ID", "TYPE", "TITLE", "VER", "LOCKED"],
+    refs.map((r) => [
+      r.id,
+      r.type,
+      r.title,
+      String(r.version),
+      r.locked ? "yes" : "no",
+    ]),
+  )
 }

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -45,6 +45,15 @@ import {
   personaActivateCommand,
 } from "./commands/persona.js"
 import { wakeCommand } from "./commands/wake.js"
+import {
+  artifactCreateCommand,
+  artifactReadCommand,
+  artifactWriteCommand,
+  artifactEditCommand,
+  artifactInspectCommand,
+  artifactListCommand,
+  artifactLockCommand,
+} from "./commands/artifact.js"
 
 type Parsed = {
   positional: string[]
@@ -112,6 +121,13 @@ const commands: Record<string, Command> = {
   "persona list": personaListCommand,
   "persona view": personaViewCommand,
   "persona activate": personaActivateCommand,
+  "artifact create": artifactCreateCommand,
+  "artifact read": artifactReadCommand,
+  "artifact write": artifactWriteCommand,
+  "artifact edit": artifactEditCommand,
+  "artifact inspect": artifactInspectCommand,
+  "artifact list": artifactListCommand,
+  "artifact lock": artifactLockCommand,
   wake: wakeCommand,
 }
 
@@ -152,6 +168,14 @@ Commands:
   persona list                        List available personas
   persona view <name>                 Show raw persona (no substitution)
   persona activate <name>             Render persona with live facts (pipe to LLM)
+
+  artifact create <type>              Create a new artifact
+  artifact read <id>                  Read artifact body (pipe-friendly)
+  artifact write <id>                 Write new body to an artifact
+  artifact edit <id>                  Edit artifact body (--old / --new)
+  artifact inspect <id>               Show artifact metadata
+  artifact list                       List artifacts (filter with flags)
+  artifact lock <id>                  Lock an artifact (append-only)
 
   wake                                Session bootstrap — identity, environment, personas
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export type {
   DreamResult,
   SporesConfig,
   NodeType,
+  NodeArtifactDef,
   NodeDef,
   EdgeDef,
   EvaluatorRef,
@@ -36,6 +37,17 @@ export type {
   WorkflowRunTerminatedOutput,
   WorkflowRunTransitionedOutput,
   WakeOutput,
+  ArtifactId,
+  ArtifactRecord,
+  ArtifactMetadata,
+  ArtifactRef,
+  ArtifactQuery,
+  ArtifactWriteMode,
+  ArtifactCreatedOutput,
+  ArtifactWrittenOutput,
+  ArtifactEditedOutput,
+  ArtifactLockedOutput,
+  ArtifactInspectedOutput,
 } from "./types.js"
 
 export type { MemoryAdapter, AdapterCapabilities } from "./memory/adapter.js"
@@ -89,3 +101,6 @@ export { KvSource } from "./sources/kv.js"
 export { match as matchDispatch } from "./dispatch/match.js"
 
 export { fireHook } from "./hooks/fire.js"
+
+export type { ArtifactAdapter, CreateArtifactInput, WriteArtifactInput } from "./artifact/adapter.js"
+export { FilesystemArtifactAdapter } from "./artifact/filesystem.js"

--- a/src/types.ts
+++ b/src/types.ts
@@ -344,6 +344,74 @@ export type DispatchHandlerHooks = {
 }
 
 // ---------------------------------------------------------------------------
+// Artifact types
+//
+// An Artifact is a named, versioned piece of content produced by an agent
+// turn — addressable, persistable, lockable, and hookable. It is the
+// standalone primitive that workflow node outputs (Transition.artifact) point
+// at once they have been persisted.
+//
+// Lifecycle: created → written (iterate | replace) → locked (append-only).
+// Deletion is intentionally absent from the MVP; locked artifacts are
+// append-only history. Archive/drop can come later once use signals it.
+// ---------------------------------------------------------------------------
+
+/** ULID-shaped identifier for an artifact. */
+export type ArtifactId = string
+
+/**
+ * The full persisted record for an artifact. `body_ref` is an
+ * adapter-defined locator — a filesystem path, blob key, etc.
+ */
+export type ArtifactRecord = {
+  id: ArtifactId
+  type: string               // aligns with NodeArtifactDef.type from workflow nodes
+  title: string
+  body_ref: string           // adapter-defined reference (FS path, blob key, etc.)
+  version: number
+  locked: boolean
+  tags: string[]
+  created_at: string         // ISO 8601
+  updated_at: string         // ISO 8601
+  derived_from?: ArtifactId  // structural edge — derivation / versioning lineage
+}
+
+/**
+ * Artifact metadata with computed fields. `pending_changes` is derived
+ * and not stored; `size_bytes` is optional and adapter-provided.
+ */
+export type ArtifactMetadata = ArtifactRecord & {
+  pending_changes: boolean
+  size_bytes?: number | undefined
+}
+
+/** Lightweight artifact reference — id + type + title only. */
+export type ArtifactRef = {
+  id: ArtifactId
+  type: string
+  title: string
+  version: number
+  locked: boolean
+  tags: string[]
+  updated_at: string
+}
+
+/** Filter for listing artifacts. All fields are optional. */
+export type ArtifactQuery = {
+  type?: string | undefined
+  tags?: string[] | undefined
+  locked?: boolean | undefined
+}
+
+/**
+ * Write mode for `artifact write`:
+ * - `iterate` — bump version number, keep prior version accessible
+ * - `replace` — overwrite current version in place (same version number)
+ * - `create` — fail if an artifact with this id already exists
+ */
+export type ArtifactWriteMode = "iterate" | "replace" | "create"
+
+// ---------------------------------------------------------------------------
 // Hook types
 // ---------------------------------------------------------------------------
 
@@ -525,4 +593,52 @@ export type WakeOutput = {
   template_path?: string | undefined // resolved path to the template file
   situational: SituationalContext
   hook?: HookInvocation | undefined
+}
+
+// ---------------------------------------------------------------------------
+// Artifact output wrappers
+// ---------------------------------------------------------------------------
+
+/**
+ * Output of `artifact create` — the newly created record plus any
+ * `artifact.created` hook that fired.
+ */
+export type ArtifactCreatedOutput = {
+  artifact: ArtifactRecord
+  hook?: HookInvocation | undefined
+}
+
+/**
+ * Output of `artifact write` — the updated record (new version if mode is
+ * `iterate`) plus any `artifact.written` hook that fired.
+ */
+export type ArtifactWrittenOutput = {
+  artifact: ArtifactRecord
+  hook?: HookInvocation | undefined
+}
+
+/**
+ * Output of `artifact edit` — the updated record plus any `artifact.edited`
+ * hook that fired.
+ */
+export type ArtifactEditedOutput = {
+  artifact: ArtifactRecord
+  hook?: HookInvocation | undefined
+}
+
+/**
+ * Output of `artifact lock` — the locked record plus any `artifact.locked`
+ * hook that fired.
+ */
+export type ArtifactLockedOutput = {
+  artifact: ArtifactRecord
+  hook?: HookInvocation | undefined
+}
+
+/**
+ * Output of `artifact inspect` — the metadata record. No hook fires on
+ * reads.
+ */
+export type ArtifactInspectedOutput = {
+  artifact: ArtifactMetadata
 }


### PR DESCRIPTION
Closes #52

## Summary

- **Types** — `ArtifactId`, `ArtifactRecord`, `ArtifactMetadata`, `ArtifactRef`, `ArtifactQuery`, `ArtifactWriteMode`, plus output wrappers (`ArtifactCreatedOutput` etc.)
- **Adapter** — `ArtifactAdapter` interface in `src/artifact/adapter.ts`
- **Filesystem impl** — `FilesystemArtifactAdapter` in `src/artifact/filesystem.ts`
  - On-disk layout: `.spores/artifacts/<ulid>/meta.json` + `v<n>.md`
  - Write modes: `iterate` (bump version), `replace` (overwrite), `create` (fail if exists)
  - Lock is idempotent; locked artifacts reject `write` / `edit`
  - Zero-dep ULID monotonic factory (same pattern as tasks)
- **CLI** — 7 verbs via `spores artifact <verb>`: `create`, `read`, `write`, `edit`, `inspect`, `list`, `lock`
  - `read` is pipe-friendly: raw body to stdout in human mode, JSON wrapper with `--json`
  - `--from <file>` flag on `create`/`write` for file-sourced body
  - Hook events: `artifact.created`, `artifact.written`, `artifact.locked`
- **Dogfood hook** — `.spores/hooks/artifact.written` indexes artifact reference into memory after every write
- **Public exports** from `src/index.ts`
- **AGENTS.md** updated with primitive table entry, on-disk layout, worked example, hook event reference

## Tests

- `src/artifact/filesystem.test.ts` — 31 tests (adapter)
- `src/cli/commands/artifact.test.ts` — 24 tests (CLI commands)
- Full suite: **423 pass, 0 fail**
- Typecheck: clean

## Base branch note

Targets `feat/structured-artifact-contract` (PR #51) because `NodeArtifactDef` and the structured artifact contract types are prereqs. This PR should merge after #51 lands on main.