### PR TITLE
feat(capability): add public declaration types and vocabulary

### DIFF
--- a/src/capability/fixtures.test.ts
+++ b/src/capability/fixtures.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Type-level fixtures for the capability declaration vocabulary (issue #69).
+ *
+ * These are not runtime tests — there is no executable logic to test in a
+ * pure-type issue. Instead, each fixture is a valid `CapabilityDef` literal
+ * that the TypeScript compiler checks at compile time. If a fixture fails to
+ * typecheck, the declaration vocabulary is missing a concept or is too
+ * narrow.
+ *
+ * Neutral examples from docs/capability-contracts.md:
+ *   - issue_tracker.list_issues
+ *   - issue_tracker.create_issue
+ *   - communication.place_call
+ *   - web.search
+ *   - document.create_slide_deck
+ */
+
+import { describe, it } from "bun:test"
+import type { CapabilityDef } from "../types.js"
+import { CAPABILITY_EFFECTS, POLICY_ERRORS } from "../types.js"
+
+// ---------------------------------------------------------------------------
+// Type-level assignment check — each fixture must satisfy CapabilityDef
+// ---------------------------------------------------------------------------
+
+const _listIssues: CapabilityDef = {
+  name: "issue_tracker.list_issues",
+  description:
+    "Use when the user asks to list issues from an external issue tracker.",
+  skill: "issue-triage",
+  requires: {
+    connections: [
+      {
+        provider: "issue_tracker",
+        capabilities: ["issues.read"],
+      },
+    ],
+  },
+  policy: {
+    effects: ["external.read"],
+  },
+}
+
+const _createIssue: CapabilityDef = {
+  name: "issue_tracker.create_issue",
+  description:
+    "Use when the user asks to create an issue in an external issue tracker.",
+  skill: "issue-triage",
+  requires: {
+    connections: [
+      {
+        provider: "issue_tracker",
+        capabilities: ["issues.write"],
+      },
+    ],
+  },
+  policy: {
+    dispatch: {
+      from: ["surface:web", "surface:chat"],
+    },
+    tools: ["integration.invoke", "approval.request"],
+    effects: ["external.write", "approval.request"],
+    approval: {
+      required_for: ["external.write"],
+      mode: "before_effect",
+    },
+  },
+  artifacts: {
+    writes: ["issue_reference"],
+  },
+}
+
+const _placeCall: CapabilityDef = {
+  name: "communication.place_call",
+  description:
+    "Use when the user asks to place an outbound call to another person.",
+  policy: {
+    dispatch: {
+      from: ["surface:chat", "surface:voice"],
+    },
+    effects: ["external.write", "user.notify", "approval.request"],
+    approval: {
+      required_for: ["external.write"],
+      mode: "before_effect",
+    },
+  },
+}
+
+const _webSearch: CapabilityDef = {
+  name: "web.search",
+  description:
+    "Use when the user asks to search the web for current information.",
+  policy: {
+    effects: ["external.read"],
+  },
+}
+
+const _createSlideDeck: CapabilityDef = {
+  name: "document.create_slide_deck",
+  description:
+    "Use when the user asks to create a slide deck from structured content.",
+  policy: {
+    effects: ["artifact.write"],
+  },
+  artifacts: {
+    writes: ["slide_deck"],
+  },
+}
+
+// Suppress "declared but never read" warnings — fixtures exist for their
+// compile-time type checks, not their runtime values.
+void _listIssues
+void _createIssue
+void _placeCall
+void _webSearch
+void _createSlideDeck
+
+// ---------------------------------------------------------------------------
+// Runtime checks — vocabulary completeness
+// ---------------------------------------------------------------------------
+
+describe("CAPABILITY_EFFECTS", () => {
+  it("contains all ten defined effects", () => {
+    const expected = [
+      "memory.read",
+      "memory.write",
+      "artifact.read",
+      "artifact.write",
+      "external.read",
+      "external.write",
+      "approval.request",
+      "dispatch.send",
+      "user.notify",
+      "compute.privileged",
+    ] as const
+    for (const effect of expected) {
+      if (!CAPABILITY_EFFECTS.includes(effect)) {
+        throw new Error(`Missing effect: ${effect}`)
+      }
+    }
+  })
+})
+
+describe("POLICY_ERRORS", () => {
+  it("contains all ten defined policy error names", () => {
+    const expected = [
+      "policy_denied",
+      "dispatch_not_allowed",
+      "tool_not_allowed",
+      "effect_not_allowed",
+      "missing_connection",
+      "approval_required",
+      "approval_rejected",
+      "provider_unauthorized",
+      "provider_unavailable",
+      "capability_misconfigured",
+    ] as const
+    for (const name of expected) {
+      if (!POLICY_ERRORS.includes(name)) {
+        throw new Error(`Missing policy error: ${name}`)
+      }
+    }
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,16 @@ export type {
   ArtifactEditedOutput,
   ArtifactLockedOutput,
   ArtifactInspectedOutput,
+  CapabilityEffect,
+  PolicyError,
+  ConnectionRequirement,
+  ApprovalMode,
+  ApprovalPolicy,
+  CapabilityPolicy,
+  CapabilityArtifacts,
+  CapabilityDef,
 } from "./types.js"
+export { CAPABILITY_EFFECTS, POLICY_ERRORS } from "./types.js"
 
 export type { MemoryAdapter, AdapterCapabilities } from "./memory/adapter.js"
 export { FilesystemAdapter } from "./memory/filesystem.js"

--- a/src/types.ts
+++ b/src/types.ts
@@ -579,6 +579,158 @@ export type WorkflowRunTransitionedOutput = {
 }
 
 // ---------------------------------------------------------------------------
+// Capability types
+//
+// A capability declaration is the host-facing execution contract around a
+// skill or procedure. It names effects, connection requirements, approval
+// policy, dispatch constraints, artifact reads/writes, and structured policy
+// error vocabulary — without assuming a particular host runtime, provider,
+// storage engine, or approval UI.
+//
+// See docs/capability-contracts.md for the design rationale and neutral
+// examples. See tnezdev/spores#68–#75 for the implementation milestone.
+// ---------------------------------------------------------------------------
+
+/**
+ * Portable names for side-effect classes produced by a capability.
+ * Hosts may define narrower internal effects; portable declarations
+ * should prefer these generic names.
+ */
+export type CapabilityEffect =
+  | "memory.read"
+  | "memory.write"
+  | "artifact.read"
+  | "artifact.write"
+  | "external.read"
+  | "external.write"
+  | "approval.request"
+  | "dispatch.send"
+  | "user.notify"
+  | "compute.privileged"
+
+/** Readonly array of all defined capability effects. Useful for validation. */
+export const CAPABILITY_EFFECTS: readonly CapabilityEffect[] = [
+  "memory.read",
+  "memory.write",
+  "artifact.read",
+  "artifact.write",
+  "external.read",
+  "external.write",
+  "approval.request",
+  "dispatch.send",
+  "user.notify",
+  "compute.privileged",
+] as const
+
+/**
+ * Structured policy failure names returned by host runtimes.
+ * The portable layer defines the vocabulary; hosts decide detection,
+ * logging, display, and recovery.
+ */
+export type PolicyError =
+  | "policy_denied"
+  | "dispatch_not_allowed"
+  | "tool_not_allowed"
+  | "effect_not_allowed"
+  | "missing_connection"
+  | "approval_required"
+  | "approval_rejected"
+  | "provider_unauthorized"
+  | "provider_unavailable"
+  | "capability_misconfigured"
+
+/** Readonly array of all defined policy error names. Useful for validation. */
+export const POLICY_ERRORS: readonly PolicyError[] = [
+  "policy_denied",
+  "dispatch_not_allowed",
+  "tool_not_allowed",
+  "effect_not_allowed",
+  "missing_connection",
+  "approval_required",
+  "approval_rejected",
+  "provider_unauthorized",
+  "provider_unavailable",
+  "capability_misconfigured",
+] as const
+
+/**
+ * Declares that a capability needs access to a user-owned or host-owned
+ * external account. Does not define where credentials live or how
+ * authorization happens — those are host responsibilities.
+ */
+export type ConnectionRequirement = {
+  /** The provider kind, e.g. `"issue_tracker"`, `"calendar"`. */
+  provider: string
+  /** The scopes or permission strings the connection must carry. */
+  capabilities: string[]
+}
+
+/** When human approval must be collected relative to the effect. */
+export type ApprovalMode = "before_effect" | "after_effect"
+
+/**
+ * Declares which effects require human approval and when approval
+ * must be collected. The host owns the approval store, notification
+ * surface, and continuation behavior.
+ */
+export type ApprovalPolicy = {
+  required_for: CapabilityEffect[]
+  mode: ApprovalMode
+}
+
+/**
+ * Execution policy for a capability: dispatch constraints, tool allowlist,
+ * expected effects, and approval requirements. All fields are optional;
+ * an absent field places no constraint on that dimension.
+ */
+export type CapabilityPolicy = {
+  /**
+   * Constrains which inbound dispatch contexts may invoke this capability.
+   * Reuses `DispatchFilter` so the same vocabulary covers web, chat, voice,
+   * scheduled jobs, agent-to-agent messages, and future host-defined sources.
+   */
+  dispatch?: DispatchFilter | undefined
+  /** Tool names the host runtime may invoke on behalf of this capability. */
+  tools?: string[] | undefined
+  /** Side-effect classes this capability may produce. */
+  effects?: CapabilityEffect[] | undefined
+  /** Approval requirements for specific effects. */
+  approval?: ApprovalPolicy | undefined
+}
+
+/**
+ * Artifact read/write references for a capability. Values are artifact
+ * kind names (strings matching `NodeArtifactDef.type` conventions).
+ * The host owns storage layout, rendering, and revision history.
+ */
+export type CapabilityArtifacts = {
+  reads?: string[] | undefined
+  writes?: string[] | undefined
+}
+
+/**
+ * A portable capability declaration — the host-facing execution contract
+ * around a skill or procedure. This is not an executor; it is input to a
+ * host runtime that enforces the policy, resolves connections, and manages
+ * approvals.
+ *
+ * `name` uses dot-separated namespacing by convention: `<domain>.<verb>`,
+ * e.g. `issue_tracker.create_issue`. `skill` optionally names a matching
+ * SKILL.md in the host's skill catalog.
+ */
+export type CapabilityDef = {
+  name: string
+  description?: string | undefined
+  /** Optional reference to a skill by name (e.g. `"issue-triage"`). */
+  skill?: string | undefined
+  requires?: {
+    connections?: ConnectionRequirement[] | undefined
+  } | undefined
+  policy?: CapabilityPolicy | undefined
+  artifacts?: CapabilityArtifacts | undefined
+}
+
+// ---------------------------------------------------------------------------
 // Wake types
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #69. Part of milestone #4 (Portable Capability Contracts), first in sequence.

## What

Adds the TypeScript type surface for portable capability declarations to `src/types.ts`:

- `CapabilityEffect` union + `CAPABILITY_EFFECTS` readonly array — the ten portable effect names from `docs/capability-contracts.md`
- `PolicyError` union + `POLICY_ERRORS` readonly array — the ten structured policy failure names
- `ConnectionRequirement` — declares a needed provider connection without binding credential storage or auth flow
- `ApprovalMode`, `ApprovalPolicy` — names when/what approval is required; host owns the store and UI
- `CapabilityPolicy` — reuses `DispatchFilter` for dispatch constraints; adds tool allowlist, effects, approval
- `CapabilityArtifacts` — reads/writes as artifact kind strings; host owns storage and rendering
- `CapabilityDef` — the top-level portable declaration shape

All new types are exported from `src/index.ts`. The two vocabulary constants (`CAPABILITY_EFFECTS`, `POLICY_ERRORS`) are exported as values alongside the types.

## Verification

`src/capability/fixtures.test.ts` provides:
- Five type-level fixtures (compiler-checked `CapabilityDef` literals) covering all neutral examples from `docs/capability-contracts.md`: `issue_tracker.list_issues`, `issue_tracker.create_issue`, `communication.place_call`, `web.search`, `document.create_slide_deck`
- Two runtime tests confirming vocabulary completeness for both constants

**468/468 tests pass. Typecheck clean. No new dependency added.**

## Scope guard

No runtime execution, no provider binding, no executor, no approval UI/store, no daemon/session layer, no hosted runtime. This is purely the declaration vocabulary as scoped by #68.