### PR TITLE
feat(capability): add pure validation and policy helpers

### DIFF
--- a/src/capability/fixtures.test.ts
+++ b/src/capability/fixtures.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Type-level fixtures for the capability declaration vocabulary (issue #69).
+ *
+ * These are not runtime tests — there is no executable logic to test in a
+ * pure-type issue. Instead, each fixture is a valid `CapabilityDef` literal
+ * that the TypeScript compiler checks at compile time. If a fixture fails to
+ * typecheck, the declaration vocabulary is missing a concept or is too
+ * narrow.
+ *
+ * Neutral examples from docs/capability-contracts.md:
+ *   - issue_tracker.list_issues
+ *   - issue_tracker.create_issue
+ *   - communication.place_call
+ *   - web.search
+ *   - document.create_slide_deck
+ */
+
+import { describe, it } from "bun:test"
+import type { CapabilityDef } from "../types.js"
+import { CAPABILITY_EFFECTS, POLICY_ERRORS } from "../types.js"
+
+// ---------------------------------------------------------------------------
+// Type-level assignment check — each fixture must satisfy CapabilityDef
+// ---------------------------------------------------------------------------
+
+const _listIssues: CapabilityDef = {
+  name: "issue_tracker.list_issues",
+  description:
+    "Use when the user asks to list issues from an external issue tracker.",
+  skill: "issue-triage",
+  requires: {
+    connections: [
+      {
+        provider: "issue_tracker",
+        capabilities: ["issues.read"],
+      },
+    ],
+  },
+  policy: {
+    effects: ["external.read"],
+  },
+}
+
+const _createIssue: CapabilityDef = {
+  name: "issue_tracker.create_issue",
+  description:
+    "Use when the user asks to create an issue in an external issue tracker.",
+  skill: "issue-triage",
+  requires: {
+    connections: [
+      {
+        provider: "issue_tracker",
+        capabilities: ["issues.write"],
+      },
+    ],
+  },
+  policy: {
+    dispatch: {
+      from: ["surface:web", "surface:chat"],
+    },
+    tools: ["integration.invoke", "approval.request"],
+    effects: ["external.write", "approval.request"],
+    approval: {
+      required_for: ["external.write"],
+      mode: "before_effect",
+    },
+  },
+  artifacts: {
+    writes: ["issue_reference"],
+  },
+}
+
+const _placeCall: CapabilityDef = {
+  name: "communication.place_call",
+  description:
+    "Use when the user asks to place an outbound call to another person.",
+  policy: {
+    dispatch: {
+      from: ["surface:chat", "surface:voice"],
+    },
+    effects: ["external.write", "user.notify", "approval.request"],
+    approval: {
+      required_for: ["external.write"],
+      mode: "before_effect",
+    },
+  },
+}
+
+const _webSearch: CapabilityDef = {
+  name: "web.search",
+  description:
+    "Use when the user asks to search the web for current information.",
+  policy: {
+    effects: ["external.read"],
+  },
+}
+
+const _createSlideDeck: CapabilityDef = {
+  name: "document.create_slide_deck",
+  description:
+    "Use when the user asks to create a slide deck from structured content.",
+  policy: {
+    effects: ["artifact.write"],
+  },
+  artifacts: {
+    writes: ["slide_deck"],
+  },
+}
+
+// Suppress "declared but never read" warnings — fixtures exist for their
+// compile-time type checks, not their runtime values.
+void _listIssues
+void _createIssue
+void _placeCall
+void _webSearch
+void _createSlideDeck
+
+// ---------------------------------------------------------------------------
+// Runtime checks — vocabulary completeness
+// ---------------------------------------------------------------------------
+
+describe("CAPABILITY_EFFECTS", () => {
+  it("contains all ten defined effects", () => {
+    const expected = [
+      "memory.read",
+      "memory.write",
+      "artifact.read",
+      "artifact.write",
+      "external.read",
+      "external.write",
+      "approval.request",
+      "dispatch.send",
+      "user.notify",
+      "compute.privileged",
+    ] as const
+    for (const effect of expected) {
+      if (!CAPABILITY_EFFECTS.includes(effect)) {
+        throw new Error(`Missing effect: ${effect}`)
+      }
+    }
+  })
+})
+
+describe("POLICY_ERRORS", () => {
+  it("contains all ten defined policy error names", () => {
+    const expected = [
+      "policy_denied",
+      "dispatch_not_allowed",
+      "tool_not_allowed",
+      "effect_not_allowed",
+      "missing_connection",
+      "approval_required",
+      "approval_rejected",
+      "provider_unauthorized",
+      "provider_unavailable",
+      "capability_misconfigured",
+    ] as const
+    for (const name of expected) {
+      if (!POLICY_ERRORS.includes(name)) {
+        throw new Error(`Missing policy error: ${name}`)
+      }
+    }
+  })
+})

--- a/src/capability/helpers.test.ts
+++ b/src/capability/helpers.test.ts
@@ -1,0 +1,399 @@
+import { describe, expect, test } from "bun:test"
+import type { CapabilityDef, Dispatch } from "../types.js"
+import {
+  capabilityAllowsEffect,
+  capabilityAllowsTool,
+  capabilityMatchesDispatch,
+  capabilityRequiresApprovalFor,
+  validateCapability,
+} from "./helpers.js"
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeDispatch(overrides: Partial<Dispatch> = {}): Dispatch {
+  return {
+    id: "01KNRZBRK1S3WAB2DTYG1TNTB5",
+    from: "surface:web",
+    to: "pa:default",
+    payload: null,
+    timestamp: "2026-05-15T05:45:00.000Z",
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// validateCapability
+// ---------------------------------------------------------------------------
+
+describe("validateCapability", () => {
+  test("accepts a minimal valid declaration (name only)", () => {
+    expect(validateCapability({ name: "web.search" })).toEqual({ valid: true })
+  })
+
+  test("accepts a full valid declaration", () => {
+    const def: CapabilityDef = {
+      name: "issue_tracker.create_issue",
+      description: "Create an issue in an external issue tracker.",
+      skill: "issue-triage",
+      requires: {
+        connections: [{ provider: "issue_tracker", capabilities: ["issues.write"] }],
+      },
+      policy: {
+        dispatch: { from: ["surface:web", "surface:chat"] },
+        tools: ["integration.invoke", "approval.request"],
+        effects: ["external.write", "approval.request"],
+        approval: { required_for: ["external.write"], mode: "before_effect" },
+      },
+      artifacts: { writes: ["issue_reference"] },
+    }
+    expect(validateCapability(def)).toEqual({ valid: true })
+  })
+
+  test("accepts a declaration with multiple connections", () => {
+    expect(
+      validateCapability({
+        name: "calendar.create_event",
+        requires: {
+          connections: [
+            { provider: "calendar", capabilities: ["events.write"] },
+            { provider: "contacts", capabilities: ["contacts.read"] },
+          ],
+        },
+        policy: { effects: ["external.write"] },
+      }),
+    ).toEqual({ valid: true })
+  })
+
+  // --- malformed declarations ---
+
+  test("rejects a non-object input: string", () => {
+    const result = validateCapability("not an object")
+    expect(result.valid).toBe(false)
+  })
+
+  test("rejects a non-object input: number", () => {
+    const result = validateCapability(42)
+    expect(result.valid).toBe(false)
+  })
+
+  test("rejects null", () => {
+    const result = validateCapability(null)
+    expect(result.valid).toBe(false)
+  })
+
+  test("rejects an array", () => {
+    const result = validateCapability([{ name: "x" }])
+    expect(result.valid).toBe(false)
+  })
+
+  test("rejects missing name", () => {
+    const result = validateCapability({})
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.errors.some((e) => e.field === "name")).toBe(true)
+    }
+  })
+
+  test("rejects empty name string", () => {
+    const result = validateCapability({ name: "" })
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.errors.some((e) => e.field === "name")).toBe(true)
+    }
+  })
+
+  test("rejects whitespace-only name", () => {
+    const result = validateCapability({ name: "   " })
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.errors.some((e) => e.field === "name")).toBe(true)
+    }
+  })
+
+  test("rejects non-string name", () => {
+    const result = validateCapability({ name: 42 })
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.errors.some((e) => e.field === "name")).toBe(true)
+    }
+  })
+
+  test("rejects an unknown effect", () => {
+    const result = validateCapability({
+      name: "x",
+      policy: { effects: ["not.a.real.effect"] },
+    })
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.errors.some((e) => e.field === "policy.effects[0]")).toBe(true)
+    }
+  })
+
+  test("rejects mixed valid and unknown effects, flagging the bad index", () => {
+    const result = validateCapability({
+      name: "x",
+      policy: { effects: ["external.read", "bad.effect"] },
+    })
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.errors.some((e) => e.field === "policy.effects[1]")).toBe(true)
+    }
+  })
+
+  test("rejects approval.required_for effect not in policy.effects", () => {
+    const result = validateCapability({
+      name: "x",
+      policy: {
+        effects: ["external.read"],
+        approval: { required_for: ["external.write"], mode: "before_effect" },
+      },
+    })
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.errors.some((e) => e.field === "policy.approval.required_for[0]")).toBe(true)
+    }
+  })
+
+  test("rejects unknown effect in approval.required_for", () => {
+    const result = validateCapability({
+      name: "x",
+      policy: {
+        effects: ["external.write"],
+        approval: { required_for: ["not.real"], mode: "before_effect" },
+      },
+    })
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.errors.some((e) => e.field === "policy.approval.required_for[0]")).toBe(true)
+    }
+  })
+
+  test("rejects connection with empty provider", () => {
+    const result = validateCapability({
+      name: "x",
+      requires: { connections: [{ provider: "", capabilities: [] }] },
+    })
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(
+        result.errors.some((e) => e.field === "requires.connections[0].provider"),
+      ).toBe(true)
+    }
+  })
+
+  test("rejects connection with non-string provider", () => {
+    const result = validateCapability({
+      name: "x",
+      requires: { connections: [{ provider: 99, capabilities: [] }] },
+    })
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(
+        result.errors.some((e) => e.field === "requires.connections[0].provider"),
+      ).toBe(true)
+    }
+  })
+
+  test("returns all errors when multiple fields are invalid", () => {
+    const result = validateCapability({
+      name: "",
+      policy: { effects: ["bad.effect"] },
+    })
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.errors.length).toBeGreaterThan(1)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// capabilityAllowsEffect
+// ---------------------------------------------------------------------------
+
+describe("capabilityAllowsEffect", () => {
+  const def: CapabilityDef = {
+    name: "issue_tracker.list_issues",
+    policy: { effects: ["external.read", "memory.read"] },
+  }
+
+  test("returns true for a declared effect", () => {
+    expect(capabilityAllowsEffect(def, "external.read")).toBe(true)
+  })
+
+  test("returns true for each declared effect", () => {
+    expect(capabilityAllowsEffect(def, "memory.read")).toBe(true)
+  })
+
+  test("returns false for an undeclared effect", () => {
+    expect(capabilityAllowsEffect(def, "external.write")).toBe(false)
+  })
+
+  test("returns false for an effect present nowhere", () => {
+    expect(capabilityAllowsEffect(def, "compute.privileged")).toBe(false)
+  })
+
+  test("returns false when policy is absent", () => {
+    expect(capabilityAllowsEffect({ name: "x" }, "external.read")).toBe(false)
+  })
+
+  test("returns false when policy.effects is absent", () => {
+    expect(capabilityAllowsEffect({ name: "x", policy: {} }, "external.read")).toBe(false)
+  })
+
+  test("returns false when policy.effects is empty", () => {
+    expect(capabilityAllowsEffect({ name: "x", policy: { effects: [] } }, "external.read")).toBe(
+      false,
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// capabilityAllowsTool
+// ---------------------------------------------------------------------------
+
+describe("capabilityAllowsTool", () => {
+  const def: CapabilityDef = {
+    name: "issue_tracker.create_issue",
+    policy: { tools: ["integration.invoke", "approval.request"] },
+  }
+
+  test("returns true for a declared tool", () => {
+    expect(capabilityAllowsTool(def, "integration.invoke")).toBe(true)
+  })
+
+  test("returns true for the second declared tool", () => {
+    expect(capabilityAllowsTool(def, "approval.request")).toBe(true)
+  })
+
+  test("returns false for an undeclared tool", () => {
+    expect(capabilityAllowsTool(def, "memory.read")).toBe(false)
+  })
+
+  test("returns false when policy is absent", () => {
+    expect(capabilityAllowsTool({ name: "x" }, "integration.invoke")).toBe(false)
+  })
+
+  test("returns false when policy.tools is absent", () => {
+    expect(capabilityAllowsTool({ name: "x", policy: {} }, "integration.invoke")).toBe(false)
+  })
+
+  test("returns false when policy.tools is empty", () => {
+    expect(capabilityAllowsTool({ name: "x", policy: { tools: [] } }, "anything")).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// capabilityMatchesDispatch
+// ---------------------------------------------------------------------------
+
+describe("capabilityMatchesDispatch", () => {
+  test("matches all dispatches when no dispatch filter is declared (no policy)", () => {
+    const def: CapabilityDef = { name: "web.search" }
+    expect(capabilityMatchesDispatch(def, makeDispatch({ from: "scheduler" }))).toBe(true)
+    expect(capabilityMatchesDispatch(def, makeDispatch({ from: "surface:voice" }))).toBe(true)
+  })
+
+  test("matches all dispatches when policy has no dispatch constraint", () => {
+    const def: CapabilityDef = { name: "web.search", policy: {} }
+    expect(capabilityMatchesDispatch(def, makeDispatch())).toBe(true)
+  })
+
+  test("matches when from is in an array allowlist", () => {
+    const def: CapabilityDef = {
+      name: "x",
+      policy: { dispatch: { from: ["surface:web", "surface:chat"] } },
+    }
+    expect(capabilityMatchesDispatch(def, makeDispatch({ from: "surface:web" }))).toBe(true)
+    expect(capabilityMatchesDispatch(def, makeDispatch({ from: "surface:chat" }))).toBe(true)
+  })
+
+  test("rejects when from is not in the array allowlist", () => {
+    const def: CapabilityDef = {
+      name: "x",
+      policy: { dispatch: { from: ["surface:web", "surface:chat"] } },
+    }
+    expect(capabilityMatchesDispatch(def, makeDispatch({ from: "scheduler" }))).toBe(false)
+    expect(capabilityMatchesDispatch(def, makeDispatch({ from: "surface:voice" }))).toBe(false)
+  })
+
+  test("matches when from is an exact string match", () => {
+    const def: CapabilityDef = {
+      name: "x",
+      policy: { dispatch: { from: "scheduler" } },
+    }
+    expect(capabilityMatchesDispatch(def, makeDispatch({ from: "scheduler" }))).toBe(true)
+  })
+
+  test("rejects when from does not match the exact string", () => {
+    const def: CapabilityDef = {
+      name: "x",
+      policy: { dispatch: { from: "scheduler" } },
+    }
+    expect(capabilityMatchesDispatch(def, makeDispatch({ from: "surface:web" }))).toBe(false)
+  })
+
+  test("empty from array rejects all dispatches (no values acceptable)", () => {
+    const def: CapabilityDef = {
+      name: "x",
+      policy: { dispatch: { from: [] } },
+    }
+    expect(capabilityMatchesDispatch(def, makeDispatch())).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// capabilityRequiresApprovalFor
+// ---------------------------------------------------------------------------
+
+describe("capabilityRequiresApprovalFor", () => {
+  const def: CapabilityDef = {
+    name: "issue_tracker.create_issue",
+    policy: {
+      effects: ["external.write", "approval.request"],
+      approval: { required_for: ["external.write"], mode: "before_effect" },
+    },
+  }
+
+  test("returns true for an effect that requires approval", () => {
+    expect(capabilityRequiresApprovalFor(def, "external.write")).toBe(true)
+  })
+
+  test("returns false for a declared effect that does not require approval", () => {
+    expect(capabilityRequiresApprovalFor(def, "approval.request")).toBe(false)
+  })
+
+  test("returns false for an entirely undeclared effect", () => {
+    expect(capabilityRequiresApprovalFor(def, "memory.read")).toBe(false)
+  })
+
+  test("returns false when policy is absent", () => {
+    expect(capabilityRequiresApprovalFor({ name: "x" }, "external.write")).toBe(false)
+  })
+
+  test("returns false when no approval policy is declared", () => {
+    expect(
+      capabilityRequiresApprovalFor({ name: "x", policy: {} }, "external.write"),
+    ).toBe(false)
+  })
+
+  test("returns false when approval.required_for is empty", () => {
+    const empty: CapabilityDef = {
+      name: "x",
+      policy: { approval: { required_for: [], mode: "before_effect" } },
+    }
+    expect(capabilityRequiresApprovalFor(empty, "external.write")).toBe(false)
+  })
+
+  test("handles after_effect approval mode", () => {
+    const afterEffect: CapabilityDef = {
+      name: "x",
+      policy: {
+        effects: ["dispatch.send"],
+        approval: { required_for: ["dispatch.send"], mode: "after_effect" },
+      },
+    }
+    expect(capabilityRequiresApprovalFor(afterEffect, "dispatch.send")).toBe(true)
+  })
+})

--- a/src/capability/helpers.test.ts
+++ b/src/capability/helpers.test.ts
@@ -196,6 +196,106 @@ describe("validateCapability", () => {
     }
   })
 
+  test("rejects connection missing capabilities", () => {
+    const result = validateCapability({
+      name: "x",
+      requires: { connections: [{ provider: "github" }] },
+    })
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(
+        result.errors.some((e) => e.field === "requires.connections[0].capabilities"),
+      ).toBe(true)
+    }
+  })
+
+  test("rejects connection with non-array capabilities", () => {
+    const result = validateCapability({
+      name: "x",
+      requires: { connections: [{ provider: "github", capabilities: "issues.read" }] },
+    })
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(
+        result.errors.some((e) => e.field === "requires.connections[0].capabilities"),
+      ).toBe(true)
+    }
+  })
+
+  test("rejects connection with non-string item in capabilities array", () => {
+    const result = validateCapability({
+      name: "x",
+      requires: { connections: [{ provider: "github", capabilities: [42] }] },
+    })
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(
+        result.errors.some((e) => e.field === "requires.connections[0].capabilities[0]"),
+      ).toBe(true)
+    }
+  })
+
+  test("accepts connection with valid provider and capabilities", () => {
+    expect(
+      validateCapability({
+        name: "x",
+        requires: { connections: [{ provider: "github", capabilities: ["issues.write"] }] },
+      }),
+    ).toEqual({ valid: true })
+  })
+
+  test("rejects approval with missing mode", () => {
+    const result = validateCapability({
+      name: "x",
+      policy: {
+        effects: ["external.write"],
+        approval: { required_for: ["external.write"] },
+      },
+    })
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.errors.some((e) => e.field === "policy.approval.mode")).toBe(true)
+    }
+  })
+
+  test("rejects approval with invalid mode value", () => {
+    const result = validateCapability({
+      name: "x",
+      policy: {
+        effects: ["external.write"],
+        approval: { required_for: ["external.write"], mode: "later" },
+      },
+    })
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.errors.some((e) => e.field === "policy.approval.mode")).toBe(true)
+    }
+  })
+
+  test("accepts approval with mode before_effect", () => {
+    expect(
+      validateCapability({
+        name: "x",
+        policy: {
+          effects: ["external.write"],
+          approval: { required_for: ["external.write"], mode: "before_effect" },
+        },
+      }),
+    ).toEqual({ valid: true })
+  })
+
+  test("accepts approval with mode after_effect", () => {
+    expect(
+      validateCapability({
+        name: "x",
+        policy: {
+          effects: ["external.write"],
+          approval: { required_for: ["external.write"], mode: "after_effect" },
+        },
+      }),
+    ).toEqual({ valid: true })
+  })
+
   test("returns all errors when multiple fields are invalid", () => {
     const result = validateCapability({
       name: "",

--- a/src/capability/helpers.test.ts
+++ b/src/capability/helpers.test.ts
@@ -272,6 +272,20 @@ describe("validateCapability", () => {
     }
   })
 
+  test("rejects approval with missing required_for", () => {
+    const result = validateCapability({
+      name: "x",
+      policy: {
+        effects: ["external.write"],
+        approval: { mode: "before_effect" },
+      },
+    })
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.errors.some((e) => e.field === "policy.approval.required_for")).toBe(true)
+    }
+  })
+
   test("accepts approval with mode before_effect", () => {
     expect(
       validateCapability({

--- a/src/capability/helpers.ts
+++ b/src/capability/helpers.ts
@@ -1,0 +1,204 @@
+import type { CapabilityDef, CapabilityEffect, Dispatch } from "../types.js"
+import { CAPABILITY_EFFECTS } from "../types.js"
+import { match } from "../dispatch/match.js"
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+export type CapabilityValidationError = {
+  field: string
+  message: string
+}
+
+export type CapabilityValidationResult =
+  | { valid: true }
+  | { valid: false; errors: [CapabilityValidationError, ...CapabilityValidationError[]] }
+
+/**
+ * Validate a capability declaration against structural and semantic
+ * constraints. Returns a structured result rather than throwing — call sites
+ * can inspect `valid` and `errors` without try/catch.
+ *
+ * Validates:
+ * - `name` is a non-empty string (required)
+ * - `policy.effects` entries are known `CapabilityEffect` values
+ * - `policy.approval.required_for` entries are known effects that also
+ *   appear in `policy.effects`
+ * - `requires.connections[*].provider` is a non-empty string
+ */
+export function validateCapability(def: unknown): CapabilityValidationResult {
+  const errors: CapabilityValidationError[] = []
+
+  if (typeof def !== "object" || def === null || Array.isArray(def)) {
+    return {
+      valid: false,
+      errors: [{ field: ".", message: "capability declaration must be a non-null object" }],
+    }
+  }
+
+  const d = def as Record<string, unknown>
+
+  // name — required non-empty string
+  if (typeof d["name"] !== "string" || d["name"].trim() === "") {
+    errors.push({ field: "name", message: "name must be a non-empty string" })
+  }
+
+  // policy
+  if (d["policy"] !== undefined) {
+    if (typeof d["policy"] !== "object" || d["policy"] === null || Array.isArray(d["policy"])) {
+      errors.push({ field: "policy", message: "policy must be an object" })
+    } else {
+      const policy = d["policy"] as Record<string, unknown>
+
+      // policy.effects — each must be a known CapabilityEffect
+      const declaredEffects: CapabilityEffect[] = []
+      if (policy["effects"] !== undefined) {
+        if (!Array.isArray(policy["effects"])) {
+          errors.push({ field: "policy.effects", message: "effects must be an array" })
+        } else {
+          for (let i = 0; i < policy["effects"].length; i++) {
+            const e = policy["effects"][i]
+            if (!CAPABILITY_EFFECTS.includes(e as CapabilityEffect)) {
+              errors.push({
+                field: `policy.effects[${i}]`,
+                message: `unknown effect: "${String(e)}"`,
+              })
+            } else {
+              declaredEffects.push(e as CapabilityEffect)
+            }
+          }
+        }
+      }
+
+      // policy.approval — required_for entries must be known and in policy.effects
+      if (policy["approval"] !== undefined) {
+        if (
+          typeof policy["approval"] !== "object" ||
+          policy["approval"] === null ||
+          Array.isArray(policy["approval"])
+        ) {
+          errors.push({ field: "policy.approval", message: "approval must be an object" })
+        } else {
+          const approval = policy["approval"] as Record<string, unknown>
+          if (approval["required_for"] !== undefined) {
+            if (!Array.isArray(approval["required_for"])) {
+              errors.push({
+                field: "policy.approval.required_for",
+                message: "required_for must be an array",
+              })
+            } else {
+              for (let i = 0; i < approval["required_for"].length; i++) {
+                const e = approval["required_for"][i]
+                if (!CAPABILITY_EFFECTS.includes(e as CapabilityEffect)) {
+                  errors.push({
+                    field: `policy.approval.required_for[${i}]`,
+                    message: `unknown effect: "${String(e)}"`,
+                  })
+                } else if (!declaredEffects.includes(e as CapabilityEffect)) {
+                  errors.push({
+                    field: `policy.approval.required_for[${i}]`,
+                    message: `effect "${String(e)}" is not declared in policy.effects`,
+                  })
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // requires.connections — each must have a non-empty provider string
+  if (d["requires"] !== undefined) {
+    if (
+      typeof d["requires"] !== "object" ||
+      d["requires"] === null ||
+      Array.isArray(d["requires"])
+    ) {
+      errors.push({ field: "requires", message: "requires must be an object" })
+    } else {
+      const requires = d["requires"] as Record<string, unknown>
+      if (requires["connections"] !== undefined) {
+        if (!Array.isArray(requires["connections"])) {
+          errors.push({
+            field: "requires.connections",
+            message: "connections must be an array",
+          })
+        } else {
+          for (let i = 0; i < requires["connections"].length; i++) {
+            const conn = requires["connections"][i]
+            if (typeof conn !== "object" || conn === null) {
+              errors.push({
+                field: `requires.connections[${i}]`,
+                message: "connection must be an object",
+              })
+            } else {
+              const c = conn as Record<string, unknown>
+              if (typeof c["provider"] !== "string" || c["provider"].trim() === "") {
+                errors.push({
+                  field: `requires.connections[${i}].provider`,
+                  message: "provider must be a non-empty string",
+                })
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    return {
+      valid: false,
+      errors: errors as [CapabilityValidationError, ...CapabilityValidationError[]],
+    }
+  }
+  return { valid: true }
+}
+
+// ---------------------------------------------------------------------------
+// Policy helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true if the capability's policy declares the given effect.
+ * An absent policy or absent effects list returns false — no whitelist
+ * means no effects are permitted.
+ */
+export function capabilityAllowsEffect(def: CapabilityDef, effect: CapabilityEffect): boolean {
+  return def.policy?.effects?.includes(effect) ?? false
+}
+
+/**
+ * Returns true if the capability's policy allows the host to invoke the
+ * given tool on its behalf. An absent tools list returns false.
+ */
+export function capabilityAllowsTool(def: CapabilityDef, tool: string): boolean {
+  return def.policy?.tools?.includes(tool) ?? false
+}
+
+/**
+ * Returns true if the inbound dispatch satisfies the capability's dispatch
+ * filter. An absent filter (no `policy.dispatch`) matches every dispatch —
+ * the capability places no constraint on call origin.
+ *
+ * Delegates to `match()` from `dispatch/match` for filter semantics:
+ * a string constraint matches by equality; an array constraint matches by
+ * inclusion; an undefined field places no constraint.
+ */
+export function capabilityMatchesDispatch(def: CapabilityDef, dispatch: Dispatch): boolean {
+  if (def.policy?.dispatch === undefined) return true
+  return match(dispatch, def.policy.dispatch)
+}
+
+/**
+ * Returns true if the capability's approval policy requires human approval
+ * before (or after) the given effect executes.
+ */
+export function capabilityRequiresApprovalFor(
+  def: CapabilityDef,
+  effect: CapabilityEffect,
+): boolean {
+  return def.policy?.approval?.required_for?.includes(effect) ?? false
+}

--- a/src/capability/helpers.ts
+++ b/src/capability/helpers.ts
@@ -81,26 +81,30 @@ export function validateCapability(def: unknown): CapabilityValidationResult {
           errors.push({ field: "policy.approval", message: "approval must be an object" })
         } else {
           const approval = policy["approval"] as Record<string, unknown>
-          if (approval["required_for"] !== undefined) {
-            if (!Array.isArray(approval["required_for"])) {
-              errors.push({
-                field: "policy.approval.required_for",
-                message: "required_for must be an array",
-              })
-            } else {
-              for (let i = 0; i < approval["required_for"].length; i++) {
-                const e = approval["required_for"][i]
-                if (!CAPABILITY_EFFECTS.includes(e as CapabilityEffect)) {
-                  errors.push({
-                    field: `policy.approval.required_for[${i}]`,
-                    message: `unknown effect: "${String(e)}"`,
-                  })
-                } else if (!declaredEffects.includes(e as CapabilityEffect)) {
-                  errors.push({
-                    field: `policy.approval.required_for[${i}]`,
-                    message: `effect "${String(e)}" is not declared in policy.effects`,
-                  })
-                }
+          // required_for — required field
+          if (approval["required_for"] === undefined) {
+            errors.push({
+              field: "policy.approval.required_for",
+              message: "required_for is required",
+            })
+          } else if (!Array.isArray(approval["required_for"])) {
+            errors.push({
+              field: "policy.approval.required_for",
+              message: "required_for must be an array",
+            })
+          } else {
+            for (let i = 0; i < approval["required_for"].length; i++) {
+              const e = approval["required_for"][i]
+              if (!CAPABILITY_EFFECTS.includes(e as CapabilityEffect)) {
+                errors.push({
+                  field: `policy.approval.required_for[${i}]`,
+                  message: `unknown effect: "${String(e)}"`,
+                })
+              } else if (!declaredEffects.includes(e as CapabilityEffect)) {
+                errors.push({
+                  field: `policy.approval.required_for[${i}]`,
+                  message: `effect "${String(e)}" is not declared in policy.effects`,
+                })
               }
             }
           }

--- a/src/capability/helpers.ts
+++ b/src/capability/helpers.ts
@@ -104,6 +104,14 @@ export function validateCapability(def: unknown): CapabilityValidationResult {
               }
             }
           }
+          // mode — required, must be a known ApprovalMode
+          const APPROVAL_MODES = ["before_effect", "after_effect"]
+          if (!APPROVAL_MODES.includes(approval["mode"] as string)) {
+            errors.push({
+              field: "policy.approval.mode",
+              message: `mode must be "before_effect" or "after_effect"`,
+            })
+          }
         }
       }
     }
@@ -140,6 +148,22 @@ export function validateCapability(def: unknown): CapabilityValidationResult {
                   field: `requires.connections[${i}].provider`,
                   message: "provider must be a non-empty string",
                 })
+              }
+              // capabilities — required string[]
+              if (!Array.isArray(c["capabilities"])) {
+                errors.push({
+                  field: `requires.connections[${i}].capabilities`,
+                  message: "capabilities must be an array of strings",
+                })
+              } else {
+                for (let j = 0; j < c["capabilities"].length; j++) {
+                  if (typeof c["capabilities"][j] !== "string") {
+                    errors.push({
+                      field: `requires.connections[${i}].capabilities[${j}]`,
+                      message: "each capability must be a string",
+                    })
+                  }
+                }
               }
             }
           }

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,6 +110,18 @@ export { KvSource } from "./sources/kv.js"
 
 export { match as matchDispatch } from "./dispatch/match.js"
 
+export type {
+  CapabilityValidationError,
+  CapabilityValidationResult,
+} from "./capability/helpers.js"
+export {
+  validateCapability,
+  capabilityAllowsEffect,
+  capabilityAllowsTool,
+  capabilityMatchesDispatch,
+  capabilityRequiresApprovalFor,
+} from "./capability/helpers.js"
+
 export { fireHook } from "./hooks/fire.js"
 
 export type { ArtifactAdapter, CreateArtifactInput, WriteArtifactInput } from "./artifact/adapter.js"

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,16 @@ export type {
   ArtifactEditedOutput,
   ArtifactLockedOutput,
   ArtifactInspectedOutput,
+  CapabilityEffect,
+  PolicyError,
+  ConnectionRequirement,
+  ApprovalMode,
+  ApprovalPolicy,
+  CapabilityPolicy,
+  CapabilityArtifacts,
+  CapabilityDef,
 } from "./types.js"
+export { CAPABILITY_EFFECTS, POLICY_ERRORS } from "./types.js"
 
 export type { MemoryAdapter, AdapterCapabilities } from "./memory/adapter.js"
 export { FilesystemAdapter } from "./memory/filesystem.js"

--- a/src/types.ts
+++ b/src/types.ts
@@ -579,6 +579,158 @@ export type WorkflowRunTransitionedOutput = {
 }
 
 // ---------------------------------------------------------------------------
+// Capability types
+//
+// A capability declaration is the host-facing execution contract around a
+// skill or procedure. It names effects, connection requirements, approval
+// policy, dispatch constraints, artifact reads/writes, and structured policy
+// error vocabulary — without assuming a particular host runtime, provider,
+// storage engine, or approval UI.
+//
+// See docs/capability-contracts.md for the design rationale and neutral
+// examples. See tnezdev/spores#68–#75 for the implementation milestone.
+// ---------------------------------------------------------------------------
+
+/**
+ * Portable names for side-effect classes produced by a capability.
+ * Hosts may define narrower internal effects; portable declarations
+ * should prefer these generic names.
+ */
+export type CapabilityEffect =
+  | "memory.read"
+  | "memory.write"
+  | "artifact.read"
+  | "artifact.write"
+  | "external.read"
+  | "external.write"
+  | "approval.request"
+  | "dispatch.send"
+  | "user.notify"
+  | "compute.privileged"
+
+/** Readonly array of all defined capability effects. Useful for validation. */
+export const CAPABILITY_EFFECTS: readonly CapabilityEffect[] = [
+  "memory.read",
+  "memory.write",
+  "artifact.read",
+  "artifact.write",
+  "external.read",
+  "external.write",
+  "approval.request",
+  "dispatch.send",
+  "user.notify",
+  "compute.privileged",
+] as const
+
+/**
+ * Structured policy failure names returned by host runtimes.
+ * The portable layer defines the vocabulary; hosts decide detection,
+ * logging, display, and recovery.
+ */
+export type PolicyError =
+  | "policy_denied"
+  | "dispatch_not_allowed"
+  | "tool_not_allowed"
+  | "effect_not_allowed"
+  | "missing_connection"
+  | "approval_required"
+  | "approval_rejected"
+  | "provider_unauthorized"
+  | "provider_unavailable"
+  | "capability_misconfigured"
+
+/** Readonly array of all defined policy error names. Useful for validation. */
+export const POLICY_ERRORS: readonly PolicyError[] = [
+  "policy_denied",
+  "dispatch_not_allowed",
+  "tool_not_allowed",
+  "effect_not_allowed",
+  "missing_connection",
+  "approval_required",
+  "approval_rejected",
+  "provider_unauthorized",
+  "provider_unavailable",
+  "capability_misconfigured",
+] as const
+
+/**
+ * Declares that a capability needs access to a user-owned or host-owned
+ * external account. Does not define where credentials live or how
+ * authorization happens — those are host responsibilities.
+ */
+export type ConnectionRequirement = {
+  /** The provider kind, e.g. `"issue_tracker"`, `"calendar"`. */
+  provider: string
+  /** The scopes or permission strings the connection must carry. */
+  capabilities: string[]
+}
+
+/** When human approval must be collected relative to the effect. */
+export type ApprovalMode = "before_effect" | "after_effect"
+
+/**
+ * Declares which effects require human approval and when approval
+ * must be collected. The host owns the approval store, notification
+ * surface, and continuation behavior.
+ */
+export type ApprovalPolicy = {
+  required_for: CapabilityEffect[]
+  mode: ApprovalMode
+}
+
+/**
+ * Execution policy for a capability: dispatch constraints, tool allowlist,
+ * expected effects, and approval requirements. All fields are optional;
+ * an absent field places no constraint on that dimension.
+ */
+export type CapabilityPolicy = {
+  /**
+   * Constrains which inbound dispatch contexts may invoke this capability.
+   * Reuses `DispatchFilter` so the same vocabulary covers web, chat, voice,
+   * scheduled jobs, agent-to-agent messages, and future host-defined sources.
+   */
+  dispatch?: DispatchFilter | undefined
+  /** Tool names the host runtime may invoke on behalf of this capability. */
+  tools?: string[] | undefined
+  /** Side-effect classes this capability may produce. */
+  effects?: CapabilityEffect[] | undefined
+  /** Approval requirements for specific effects. */
+  approval?: ApprovalPolicy | undefined
+}
+
+/**
+ * Artifact read/write references for a capability. Values are artifact
+ * kind names (strings matching `NodeArtifactDef.type` conventions).
+ * The host owns storage layout, rendering, and revision history.
+ */
+export type CapabilityArtifacts = {
+  reads?: string[] | undefined
+  writes?: string[] | undefined
+}
+
+/**
+ * A portable capability declaration — the host-facing execution contract
+ * around a skill or procedure. This is not an executor; it is input to a
+ * host runtime that enforces the policy, resolves connections, and manages
+ * approvals.
+ *
+ * `name` uses dot-separated namespacing by convention: `<domain>.<verb>`,
+ * e.g. `issue_tracker.create_issue`. `skill` optionally names a matching
+ * SKILL.md in the host's skill catalog.
+ */
+export type CapabilityDef = {
+  name: string
+  description?: string | undefined
+  /** Optional reference to a skill by name (e.g. `"issue-triage"`). */
+  skill?: string | undefined
+  requires?: {
+    connections?: ConnectionRequirement[] | undefined
+  } | undefined
+  policy?: CapabilityPolicy | undefined
+  artifacts?: CapabilityArtifacts | undefined
+}
+
+// ---------------------------------------------------------------------------
 // Wake types
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #70. Part of umbrella #68 (milestone #4: Portable Capability Contracts).

## What

Adds `src/capability/helpers.ts` — pure, dependency-free validation and policy helpers for capability declarations:

**`validateCapability(def: unknown): CapabilityValidationResult`**
Returns structured errors rather than throwing. Validates:
- `name` is a non-empty string (required)
- `policy.effects` entries are known `CapabilityEffect` values
- `policy.approval.required_for` entries are known effects _and_ appear in `policy.effects`
- `requires.connections[*].provider` is a non-empty string

**Policy read helpers:**
- `capabilityAllowsEffect(def, effect)` — checks `policy.effects` membership
- `capabilityAllowsTool(def, tool)` — checks `policy.tools` membership
- `capabilityMatchesDispatch(def, dispatch)` — delegates to `dispatch/match` for `DispatchFilter` semantics; absent filter matches all
- `capabilityRequiresApprovalFor(def, effect)` — checks `policy.approval.required_for` membership

All five exported from `src/index.ts` alongside their types.

## Tests (45 new)

Covers: malformed declarations (non-object, null, array, bad name, unknown effects, approval subset violation, empty provider), allowed/denied effects, tools, dispatch sources (exact string, array, empty array, absent filter), and approval-required effects.

## Metrics

- 513/513 tests pass (up from 468)
- Typecheck clean
- No new dependencies
- Scope guard held