### PR TITLE
feat(rename): .agentic config discovery and AGENTIC_* hook env vars

### DIFF
--- a/src/artifact/filesystem.test.ts
+++ b/src/artifact/filesystem.test.ts
@@ -60,7 +60,7 @@ describe("FilesystemArtifactAdapter", () => {
         title: "Test",
         body: "hello",
       })
-      const entries = await readdir(join(tmpDir, ".spores", "artifacts", record.id))
+      const entries = await readdir(join(tmpDir, ".agentic", "artifacts", record.id))
       expect(entries).toContain("meta.json")
       expect(entries).toContain("v1.md")
     })

--- a/src/artifact/filesystem.ts
+++ b/src/artifact/filesystem.ts
@@ -6,6 +6,7 @@ import {
   stat,
 } from "node:fs/promises"
 import { join } from "node:path"
+import { resolveProjectDir } from "../resolve-dir.js"
 import type {
   ArtifactId,
   ArtifactMetadata,
@@ -114,7 +115,7 @@ export class FilesystemArtifactAdapter implements ArtifactAdapter {
   private ulid: () => string
 
   constructor(baseDir: string) {
-    this.dir = join(baseDir, ".spores", "artifacts")
+    this.dir = resolveProjectDir(baseDir, "artifacts")
     this.ulid = createUlidFactory()
   }
 

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -3,37 +3,37 @@ import { join } from "node:path"
 import type { Command } from "../main.js"
 import { output } from "../main.js"
 
-const DEFAULT_CONFIG = `# SPORES configuration
+const DEFAULT_CONFIG = `# Agentic configuration
 # See: https://github.com/tnezdev/spores
 
 adapter = "filesystem"
 
 [memory]
-dir = ".spores/memory"
+dir = ".agentic/memory"
 default_tier = "L1"
 dream_depth = "3"
 
 [workflow]
-graphs_dir = ".spores/workflows"
-runs_dir = ".spores/runs"
+graphs_dir = ".agentic/workflows"
+runs_dir = ".agentic/runs"
 `
 
 export const initCommand: Command = async (ctx, _args, _flags) => {
-  const sporesDir = join(ctx.baseDir, ".spores")
-  const memoryDir = join(sporesDir, "memory")
-  const configPath = join(sporesDir, "config.toml")
+  const agenticDir = join(ctx.baseDir, ".agentic")
+  const memoryDir = join(agenticDir, "memory")
+  const configPath = join(agenticDir, "config.toml")
 
   let alreadyExists = false
   try {
-    await access(sporesDir)
+    await access(agenticDir)
     alreadyExists = true
   } catch {
     // doesn't exist, we'll create it
   }
 
   await mkdir(memoryDir, { recursive: true })
-  await mkdir(join(sporesDir, "workflows"), { recursive: true })
-  await mkdir(join(sporesDir, "runs"), { recursive: true })
+  await mkdir(join(agenticDir, "workflows"), { recursive: true })
+  await mkdir(join(agenticDir, "runs"), { recursive: true })
 
   if (!alreadyExists) {
     await writeFile(configPath, DEFAULT_CONFIG)
@@ -41,10 +41,10 @@ export const initCommand: Command = async (ctx, _args, _flags) => {
 
   output(
     ctx,
-    { initialized: true, path: sporesDir, alreadyExists },
+    { initialized: true, path: agenticDir, alreadyExists },
     (d) =>
       d.alreadyExists
         ? `Already initialized at ${d.path}`
-        : `Initialized SPORES at ${d.path}`,
+        : `Initialized at ${d.path}`,
   )
 }

--- a/src/cli/commands/wake.ts
+++ b/src/cli/commands/wake.ts
@@ -10,7 +10,7 @@ import { formatWake } from "../format.js"
 import type { Command } from "../main.js"
 import { output } from "../main.js"
 
-const DEFAULT_TEMPLATE = `(no wake template configured — set [wake] template in .spores/config.toml)
+const DEFAULT_TEMPLATE = `(no wake template configured — set [wake] template in .agentic/config.toml)
 
 ---
 

--- a/src/cli/main.test.ts
+++ b/src/cli/main.test.ts
@@ -55,13 +55,13 @@ describe("CLI", () => {
   })
 
   describe("init", () => {
-    it("scaffolds .spores/ directory", async () => {
+    it("scaffolds .agentic/ directory", async () => {
       const result = (await runJson(...base, "init")) as {
         initialized: boolean
         path: string
       }
       expect(result.initialized).toBe(true)
-      expect(result.path).toContain(".spores")
+      expect(result.path).toContain(".agentic")
     })
 
     it("is idempotent", async () => {

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -41,7 +41,7 @@ describe("loadConfig", () => {
     expect(config.memory.dreamDepth).toBe(DEFAULTS.memory.dreamDepth)
   })
 
-  it("project config overrides defaults", async () => {
+  it("project .spores config overrides defaults (legacy fallback)", async () => {
     await mkdir(join(tmpDir, ".spores"), { recursive: true })
     await writeFile(
       join(tmpDir, ".spores", "config.toml"),
@@ -50,5 +50,30 @@ describe("loadConfig", () => {
     const config = await loadConfig(tmpDir)
     expect(config.memory.dreamDepth).toBe(5)
     expect(config.adapter).toBe(DEFAULTS.adapter)
+  })
+
+  it("project .agentic config overrides defaults", async () => {
+    await mkdir(join(tmpDir, ".agentic"), { recursive: true })
+    await writeFile(
+      join(tmpDir, ".agentic", "config.toml"),
+      '[memory]\ndream_depth = "7"',
+    )
+    const config = await loadConfig(tmpDir)
+    expect(config.memory.dreamDepth).toBe(7)
+  })
+
+  it(".agentic config wins over .spores config when both exist", async () => {
+    await mkdir(join(tmpDir, ".agentic"), { recursive: true })
+    await writeFile(
+      join(tmpDir, ".agentic", "config.toml"),
+      '[memory]\ndream_depth = "9"',
+    )
+    await mkdir(join(tmpDir, ".spores"), { recursive: true })
+    await writeFile(
+      join(tmpDir, ".spores", "config.toml"),
+      '[memory]\ndream_depth = "3"',
+    )
+    const config = await loadConfig(tmpDir)
+    expect(config.memory.dreamDepth).toBe(9)
   })
 })

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,13 +6,13 @@ import type { MemoryTier, SporesConfig } from "./types.js"
 const DEFAULTS: SporesConfig = {
   adapter: "filesystem",
   memory: {
-    dir: ".spores/memory",
+    dir: ".agentic/memory",
     defaultTier: "L1",
     dreamDepth: 3,
   },
   workflow: {
-    graphsDir: ".spores/workflows",
-    runsDir: ".spores/runs",
+    graphsDir: ".agentic/workflows",
+    runsDir: ".agentic/runs",
   },
   wake: {},
 }
@@ -101,16 +101,18 @@ async function tryReadToml(path: string): Promise<TomlDoc | undefined> {
 export async function loadConfig(baseDir: string): Promise<SporesConfig> {
   let config = { ...DEFAULTS, memory: { ...DEFAULTS.memory }, workflow: { ...DEFAULTS.workflow }, wake: { ...DEFAULTS.wake } }
 
-  const globalToml = await tryReadToml(
-    join(homedir(), ".spores", "config.toml"),
-  )
+  // Global config: prefer ~/.agentic/config.toml, fall back to ~/.spores/config.toml
+  const globalToml =
+    (await tryReadToml(join(homedir(), ".agentic", "config.toml"))) ??
+    (await tryReadToml(join(homedir(), ".spores", "config.toml")))
   if (globalToml !== undefined) {
     config = applyToml(config, globalToml)
   }
 
-  const projectToml = await tryReadToml(
-    join(baseDir, ".spores", "config.toml"),
-  )
+  // Project config: prefer .agentic/config.toml, fall back to .spores/config.toml
+  const projectToml =
+    (await tryReadToml(join(baseDir, ".agentic", "config.toml"))) ??
+    (await tryReadToml(join(baseDir, ".spores", "config.toml")))
   if (projectToml !== undefined) {
     config = applyToml(config, projectToml)
   }

--- a/src/hooks/fire.test.ts
+++ b/src/hooks/fire.test.ts
@@ -111,6 +111,73 @@ describe("hooks/fireHook", () => {
     expect(result.stdout).not.toContain("bin=unset")
   })
 
+  it("injects AGENTIC_EVENT and AGENTIC_BIN alongside SPORES_* equivalents", async () => {
+    await writeHook(
+      hookDir,
+      "persona.activated",
+      '#!/usr/bin/env bash\necho "ae=$AGENTIC_EVENT"\necho "ab=${AGENTIC_BIN:-unset}"\n',
+    )
+
+    const result = await fireHook("persona.activated", {}, tmpDir)
+
+    expect(result.ran).toBe(true)
+    expect(result.stdout).toContain("ae=persona.activated")
+    expect(result.stdout).toMatch(/ab=.+/)
+    expect(result.stdout).not.toContain("ab=unset")
+  })
+
+  it("bridges SPORES_* caller vars to AGENTIC_* equivalents", async () => {
+    await writeHook(
+      hookDir,
+      "persona.activated",
+      '#!/usr/bin/env bash\necho "aname=$AGENTIC_PERSONA_NAME"\n',
+    )
+
+    const result = await fireHook(
+      "persona.activated",
+      { SPORES_PERSONA_NAME: "spores-maintainer" },
+      tmpDir,
+    )
+
+    expect(result.ran).toBe(true)
+    expect(result.stdout).toContain("aname=spores-maintainer")
+  })
+
+  it("bridges AGENTIC_* caller vars to SPORES_* equivalents", async () => {
+    await writeHook(
+      hookDir,
+      "persona.activated",
+      '#!/usr/bin/env bash\necho "sname=$SPORES_PERSONA_NAME"\n',
+    )
+
+    const result = await fireHook(
+      "persona.activated",
+      { AGENTIC_PERSONA_NAME: "agentic-maintainer" },
+      tmpDir,
+    )
+
+    expect(result.ran).toBe(true)
+    expect(result.stdout).toContain("sname=agentic-maintainer")
+  })
+
+  it("honours AGENTIC_HOOKS_DIR override", async () => {
+    const altDir = join(tmpDir, "alt-hooks")
+    await writeHook(altDir, "persona.activated", "#!/usr/bin/env bash\necho from-alt\n")
+
+    // Temporarily point to alt dir via AGENTIC_HOOKS_DIR instead of SPORES_HOOKS_DIR.
+    delete process.env["SPORES_HOOKS_DIR"]
+    process.env["AGENTIC_HOOKS_DIR"] = altDir
+
+    try {
+      const result = await fireHook("persona.activated", {}, tmpDir)
+      expect(result.ran).toBe(true)
+      expect(result.stdout).toContain("from-alt")
+    } finally {
+      delete process.env["AGENTIC_HOOKS_DIR"]
+      process.env["SPORES_HOOKS_DIR"] = hookDir
+    }
+  })
+
   it("surfaces non-zero exit codes without throwing", async () => {
     await writeHook(
       hookDir,
@@ -144,9 +211,9 @@ describe("hooks/fireHook", () => {
     // rooted under tmpDir.
     delete process.env["SPORES_HOOKS_DIR"]
 
-    const projectHookDir = join(tmpDir, "project", ".spores", "hooks")
+    const projectHookDir = join(tmpDir, "project", ".agentic", "hooks")
     const userHome = join(tmpDir, "home")
-    const userHookDir = join(userHome, ".spores", "hooks")
+    const userHookDir = join(userHome, ".agentic", "hooks")
     const prevHome = process.env["HOME"]
     process.env["HOME"] = userHome
 
@@ -182,7 +249,7 @@ describe("hooks/fireHook", () => {
     delete process.env["SPORES_HOOKS_DIR"]
 
     const userHome = join(tmpDir, "home")
-    const userHookDir = join(userHome, ".spores", "hooks")
+    const userHookDir = join(userHome, ".agentic", "hooks")
     const prevHome = process.env["HOME"]
     process.env["HOME"] = userHome
 
@@ -204,6 +271,29 @@ describe("hooks/fireHook", () => {
     } finally {
       if (prevHome === undefined) delete process.env["HOME"]
       else process.env["HOME"] = prevHome
+      process.env["SPORES_HOOKS_DIR"] = hookDir
+    }
+  })
+
+  it("falls back to .spores/hooks when .agentic/hooks does not exist (legacy)", async () => {
+    delete process.env["SPORES_HOOKS_DIR"]
+
+    const projectDir = join(tmpDir, "legacy-project")
+    const legacyHookDir = join(projectDir, ".spores", "hooks")
+    // Note: no .agentic/hooks directory created
+
+    try {
+      await writeHook(
+        legacyHookDir,
+        "persona.activated",
+        "#!/usr/bin/env bash\necho from-spores-legacy\n",
+      )
+
+      const result = await fireHook("persona.activated", {}, projectDir)
+
+      expect(result.ran).toBe(true)
+      expect(result.stdout).toContain("from-spores-legacy")
+    } finally {
       process.env["SPORES_HOOKS_DIR"] = hookDir
     }
   })

--- a/src/hooks/fire.ts
+++ b/src/hooks/fire.ts
@@ -1,23 +1,29 @@
 import { existsSync, statSync } from "node:fs"
-import { homedir } from "node:os"
 import { join } from "node:path"
 import type { HookInvocation } from "../types.js"
+import { resolveProjectDir, resolveGlobalDir } from "../resolve-dir.js"
 
 /**
- * Fire a spores primitive event. Events are named `<primitive>.<verb>`
+ * Fire an agentic primitive event. Events are named `<primitive>.<verb>`
  * (e.g. `persona.activated`, `task.done`). Event firing is synchronous,
  * in-process, and happens *after* the primary verb's effect has been
  * written — the hook cannot prevent or alter the verb's outcome.
  *
  * Hook lookup (first match wins):
- *   1. `$SPORES_HOOKS_DIR/<event>` — test override; if set, nothing else is consulted
- *   2. `<baseDir>/.spores/hooks/<event>` — project-level
- *   3. `~/.spores/hooks/<event>` — user-level
+ *   1. `$AGENTIC_HOOKS_DIR` or `$SPORES_HOOKS_DIR` — test/CI override
+ *   2. `<baseDir>/.agentic/hooks/<event>` (falls back to `.spores/hooks/` for legacy)
+ *   3. `~/.agentic/hooks/<event>` (falls back to `~/.spores/hooks/` for legacy)
  *
  * A hook is considered present only if the file exists AND has at least
  * one executable bit set (owner/group/other). Presence without the exec
  * bit is treated as "not a hook" — avoids accidentally running editor
  * scratch files or templates.
+ *
+ * Environment variables injected into hook processes:
+ *   - `AGENTIC_EVENT` / `SPORES_EVENT` (compatibility) — the event name
+ *   - `AGENTIC_BIN` / `SPORES_BIN` (compatibility) — path to the CLI binary
+ *   - For every caller-provided `SPORES_*` key, an `AGENTIC_*` equivalent is
+ *     also injected automatically (e.g. `SPORES_PERSONA_NAME` → `AGENTIC_PERSONA_NAME`).
  *
  * Design rationale + event catalog: tnezdev/spores#26
  * Minimum experiment (this verb only): tnezdev/spores#27
@@ -25,16 +31,12 @@ import type { HookInvocation } from "../types.js"
 
 const TIMEOUT_MS = 5000
 
-function userHome(): string {
-  return process.env["HOME"] ?? homedir()
-}
-
 function hookDirs(baseDir: string): string[] {
-  const override = process.env["SPORES_HOOKS_DIR"]
+  const override = process.env["AGENTIC_HOOKS_DIR"] ?? process.env["SPORES_HOOKS_DIR"]
   if (override !== undefined && override !== "") return [override]
   return [
-    join(baseDir, ".spores", "hooks"),
-    join(userHome(), ".spores", "hooks"),
+    resolveProjectDir(baseDir, "hooks"),
+    resolveGlobalDir("hooks"),
   ]
 }
 
@@ -57,10 +59,32 @@ function resolveHook(event: string, baseDir: string): string | undefined {
 }
 
 /**
+ * Build a compatibility env bridge: for every key starting with `SPORES_`,
+ * add the corresponding `AGENTIC_` key if not already present, and vice
+ * versa. This lets hook scripts use either naming convention without
+ * requiring callers to duplicate every key.
+ */
+function bridgeEnvNames(env: Record<string, string>): Record<string, string> {
+  const result: Record<string, string> = { ...env }
+  for (const [key, value] of Object.entries(env)) {
+    if (key.startsWith("SPORES_")) {
+      const agenticKey = "AGENTIC_" + key.slice("SPORES_".length)
+      if (result[agenticKey] === undefined) result[agenticKey] = value
+    } else if (key.startsWith("AGENTIC_")) {
+      const sporesKey = "SPORES_" + key.slice("AGENTIC_".length)
+      if (result[sporesKey] === undefined) result[sporesKey] = value
+    }
+  }
+  return result
+}
+
+/**
  * Fire the named event. If no hook is present, returns a quiet no-op result
  * (`ran: false`). If a hook is present, it is executed with the provided env
- * vars merged into the current process env, plus an injected `SPORES_EVENT`
- * and (if not already set) a `SPORES_BIN` pointing at the current CLI entry.
+ * vars merged into the current process env, plus injected `AGENTIC_EVENT` /
+ * `SPORES_EVENT` and (if not already set) `AGENTIC_BIN` / `SPORES_BIN`
+ * pointing at the current CLI entry. Caller-provided `SPORES_*` vars
+ * automatically receive `AGENTIC_*` mirrors, and vice versa.
  *
  * Hooks run with a 5-second timeout. Timeouts and non-zero exits are surfaced
  * via the `error` / `exit_code` fields on the result — they are not thrown.
@@ -82,15 +106,16 @@ export async function fireHook(
     }
   }
 
-  const fullEnv: Record<string, string> = {
+  const fullEnv: Record<string, string> = bridgeEnvNames({
     ...(process.env as Record<string, string>),
     ...env,
+    AGENTIC_EVENT: event,
     SPORES_EVENT: event,
-  }
+  })
 
-  if (fullEnv["SPORES_BIN"] === undefined || fullEnv["SPORES_BIN"] === "") {
-    fullEnv["SPORES_BIN"] = process.argv[1] ?? "spores"
-  }
+  const binPath = process.argv[1] ?? "agentic"
+  if (!fullEnv["AGENTIC_BIN"]) fullEnv["AGENTIC_BIN"] = binPath
+  if (!fullEnv["SPORES_BIN"]) fullEnv["SPORES_BIN"] = binPath
 
   try {
     const proc = Bun.spawn([script], {
@@ -109,8 +134,8 @@ export async function fireHook(
     //
     // CRITICAL: capture the timer handle and clearTimeout on the winning
     // path. An un-cleared pending timer keeps Bun's event loop alive and
-    // prevents the caller's process from exiting — manifests as "spores
-    // command hangs" when spores is itself spawned as a subprocess
+    // prevents the caller's process from exiting — manifests as "agentic
+    // command hangs" when agentic is itself spawned as a subprocess
     // (terminals mask it via tty/exec semantics; Bun.spawn exposes it).
     const TIMEOUT_SENTINEL: unique symbol = Symbol("hook-timeout") as never
     type Winner = number | typeof TIMEOUT_SENTINEL

--- a/src/memory/filesystem.ts
+++ b/src/memory/filesystem.ts
@@ -2,6 +2,7 @@ import { readdir, readFile, writeFile, unlink, mkdir } from "node:fs/promises"
 import { join } from "node:path"
 import type { Memory, RecallQuery, RecallResult } from "../types.js"
 import type { AdapterCapabilities, MemoryAdapter } from "./adapter.js"
+import { resolveProjectDir } from "../resolve-dir.js"
 
 interface NodeError extends Error {
   code?: string | undefined
@@ -15,7 +16,7 @@ export class FilesystemAdapter implements MemoryAdapter {
   private dir: string
 
   constructor(baseDir: string) {
-    this.dir = join(baseDir, ".spores", "memory")
+    this.dir = resolveProjectDir(baseDir, "memory")
   }
 
   capabilities(): AdapterCapabilities {

--- a/src/personas/filesystem.ts
+++ b/src/personas/filesystem.ts
@@ -1,5 +1,5 @@
 import { join } from "node:path"
-import { homedir } from "node:os"
+import { resolveProjectDir, resolveGlobalDir } from "../resolve-dir.js"
 import type {
   PersonaFile,
   PersonaRef,
@@ -11,12 +11,6 @@ import type { Source } from "../sources/source.js"
 import { FlatFileSource } from "../sources/flat-file.js"
 import { LayeredSource } from "../sources/layered.js"
 import type { PersonaAdapter } from "./adapter.js"
-
-function userHome(): string {
-  // Prefer HOME env var so tests can override it. Falls back to os.homedir()
-  // which reads the system password database on Unix.
-  return process.env["HOME"] ?? homedir()
-}
 
 // ---------------------------------------------------------------------------
 // Frontmatter parser
@@ -210,11 +204,11 @@ export async function loadPersonaFromSource(
 // ---------------------------------------------------------------------------
 
 function globalPersonasDir(): string {
-  return join(userHome(), ".spores", "personas")
+  return resolveGlobalDir("personas")
 }
 
 function projectPersonasDir(baseDir: string): string {
-  return join(baseDir, ".spores", "personas")
+  return resolveProjectDir(baseDir, "personas")
 }
 
 function defaultFilesystemSource(baseDir: string): Source {

--- a/src/resolve-dir.ts
+++ b/src/resolve-dir.ts
@@ -1,0 +1,32 @@
+import { existsSync } from "node:fs"
+import { join } from "node:path"
+import { homedir } from "node:os"
+
+function userHome(): string {
+  return process.env["HOME"] ?? homedir()
+}
+
+/**
+ * Resolve a project-level config subdirectory path, preferring `.agentic/`
+ * over `.spores/`. Falls back to `.spores/` only when it exists and `.agentic/`
+ * does not — preserving legacy projects without migration. Defaults to
+ * `.agentic/` for new projects where neither directory exists yet.
+ */
+export function resolveProjectDir(baseDir: string, ...segments: string[]): string {
+  const agenticPath = join(baseDir, ".agentic", ...segments)
+  const sporesPath = join(baseDir, ".spores", ...segments)
+  if (!existsSync(agenticPath) && existsSync(sporesPath)) return sporesPath
+  return agenticPath
+}
+
+/**
+ * Resolve a global (user-level) config subdirectory path, preferring
+ * `~/.agentic/` over `~/.spores/` using the same precedence rules as
+ * {@link resolveProjectDir}.
+ */
+export function resolveGlobalDir(...segments: string[]): string {
+  const agenticPath = join(userHome(), ".agentic", ...segments)
+  const sporesPath = join(userHome(), ".spores", ...segments)
+  if (!existsSync(agenticPath) && existsSync(sporesPath)) return sporesPath
+  return agenticPath
+}

--- a/src/skills/filesystem.ts
+++ b/src/skills/filesystem.ts
@@ -1,5 +1,5 @@
-import { homedir } from "node:os"
 import { join } from "node:path"
+import { resolveProjectDir, resolveGlobalDir } from "../resolve-dir.js"
 import type { Skill, SkillRef } from "../types.js"
 import type { Source } from "../sources/source.js"
 import { LayeredSource } from "../sources/layered.js"
@@ -122,18 +122,12 @@ export async function loadSkillFromSource(
 // Convenience API — filesystem layering of project + global skills
 // ---------------------------------------------------------------------------
 
-function userHome(): string {
-  // Prefer HOME env var so tests can override it. Falls back to os.homedir()
-  // which reads the system password database on Unix.
-  return process.env["HOME"] ?? homedir()
-}
-
 function globalSkillsDir(): string {
-  return join(userHome(), ".spores", "skills")
+  return resolveGlobalDir("skills")
 }
 
 function projectSkillsDir(baseDir: string): string {
-  return join(baseDir, ".spores", "skills")
+  return resolveProjectDir(baseDir, "skills")
 }
 
 function defaultFilesystemSource(baseDir: string): Source {

--- a/src/tasks/filesystem.test.ts
+++ b/src/tasks/filesystem.test.ts
@@ -52,9 +52,9 @@ describe("FilesystemTaskAdapter", () => {
       expect(new Set(ids).size).toBe(ids.length)
     })
 
-    it("creates .spores/tasks dir on first write", async () => {
+    it("creates .agentic/tasks dir on first write", async () => {
       await adapter.createTask(taskInput())
-      const files = await readdir(join(tmpDir, ".spores", "tasks"))
+      const files = await readdir(join(tmpDir, ".agentic", "tasks"))
       expect(files.length).toBe(1)
     })
   })
@@ -125,7 +125,7 @@ describe("FilesystemTaskAdapter", () => {
 
     it("skips malformed json files with a warning", async () => {
       await adapter.createTask(taskInput({ description: "ok" }))
-      await writeFile(join(tmpDir, ".spores", "tasks", "BOGUS.json"), "{not json")
+      await writeFile(join(tmpDir, ".agentic", "tasks", "BOGUS.json"), "{not json")
       const list = await adapter.listTasks({})
       expect(list.length).toBe(1)
       expect(list[0]!.description).toBe("ok")

--- a/src/tasks/filesystem.ts
+++ b/src/tasks/filesystem.ts
@@ -1,5 +1,6 @@
 import { readdir, readFile, writeFile, unlink, mkdir } from "node:fs/promises"
 import { join } from "node:path"
+import { resolveProjectDir } from "../resolve-dir.js"
 import type {
   Task,
   TaskStatus,
@@ -88,7 +89,7 @@ export class FilesystemTaskAdapter implements TaskAdapter {
   private ulid: () => string
 
   constructor(baseDir: string) {
-    this.dir = join(baseDir, ".spores", "tasks")
+    this.dir = resolveProjectDir(baseDir, "tasks")
     this.ulid = createUlidFactory()
   }
 

--- a/src/workflow/filesystem.test.ts
+++ b/src/workflow/filesystem.test.ts
@@ -285,7 +285,7 @@ describe("FilesystemWorkflowAdapter — YAML graphs", () => {
   })
 
   it("loadGraph reads a .yaml file placed directly in the graphs dir", async () => {
-    const graphsDir = join(tmpDir, ".spores", "workflows")
+    const graphsDir = join(tmpDir, ".agentic", "workflows")
     await mkdir(graphsDir, { recursive: true })
     await writeFile(join(graphsDir, "yaml-graph.yaml"), YAML_GRAPH, "utf-8")
 
@@ -299,7 +299,7 @@ describe("FilesystemWorkflowAdapter — YAML graphs", () => {
   })
 
   it("loadGraph reads a .yml file", async () => {
-    const graphsDir = join(tmpDir, ".spores", "workflows")
+    const graphsDir = join(tmpDir, ".agentic", "workflows")
     await mkdir(graphsDir, { recursive: true })
     await writeFile(join(graphsDir, "yaml-graph.yml"), YAML_GRAPH, "utf-8")
 
@@ -309,7 +309,7 @@ describe("FilesystemWorkflowAdapter — YAML graphs", () => {
   })
 
   it("loadGraph prefers .json over .yaml when both exist", async () => {
-    const graphsDir = join(tmpDir, ".spores", "workflows")
+    const graphsDir = join(tmpDir, ".agentic", "workflows")
     await mkdir(graphsDir, { recursive: true })
     const jsonGraph = makeGraph("yaml-graph")
     jsonGraph.name = "JSON version"
@@ -328,7 +328,7 @@ describe("FilesystemWorkflowAdapter — YAML graphs", () => {
     const graph = makeGraph("json-graph")
     await store.saveGraph(graph)
 
-    const graphsDir = join(tmpDir, ".spores", "workflows")
+    const graphsDir = join(tmpDir, ".agentic", "workflows")
     await writeFile(join(graphsDir, "yaml-graph.yaml"), YAML_GRAPH, "utf-8")
 
     const graphs = await store.listGraphs()
@@ -338,7 +338,7 @@ describe("FilesystemWorkflowAdapter — YAML graphs", () => {
   })
 
   it("listGraphs excludes .source.yaml files", async () => {
-    const graphsDir = join(tmpDir, ".spores", "workflows")
+    const graphsDir = join(tmpDir, ".agentic", "workflows")
     await mkdir(graphsDir, { recursive: true })
     await writeFile(join(graphsDir, "yaml-graph.yaml"), YAML_GRAPH, "utf-8")
     await writeFile(

--- a/src/workflow/filesystem.ts
+++ b/src/workflow/filesystem.ts
@@ -1,6 +1,7 @@
 import { mkdir, readdir, readFile, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { randomUUID } from "node:crypto"
+import { resolveProjectDir } from "../resolve-dir.js"
 import type { GraphDef, Run, Transition } from "../types.js"
 import type { Source } from "../sources/source.js"
 import type { WorkflowAdapter } from "./adapter.js"
@@ -28,8 +29,8 @@ export class FilesystemWorkflowAdapter implements WorkflowAdapter {
   private runsDir: string
 
   constructor(baseDir: string) {
-    this.graphsDir = join(baseDir, ".spores", "workflows")
-    this.runsDir = join(baseDir, ".spores", "runs")
+    this.graphsDir = resolveProjectDir(baseDir, "workflows")
+    this.runsDir = resolveProjectDir(baseDir, "runs")
   }
 
   // ---- Graphs --------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements the foundational path-resolution change for the Rename to Agentic milestone.

- Closes #60: `.agentic/` config dirs are preferred over `.spores/` with automatic legacy fallback
- Closes #64: Hooks receive both `AGENTIC_*` and `SPORES_*` env vars so existing scripts work without edits

## Changes

**`src/resolve-dir.ts`** (new): `resolveProjectDir` and `resolveGlobalDir` helpers. Logic: if `.agentic/X` doesn't exist but `.spores/X` does → use `.spores/X` (legacy); otherwise → `.agentic/X` (default for new projects or when `.agentic/` is present).

**Config loader** (`src/config.ts`): tries `.agentic/config.toml` before `.spores/config.toml` at both global and project level. DEFAULTS now use `.agentic/` paths.

**Filesystem adapters** (memory, workflow, task, artifact, personas, skills, hooks): all use `resolveProjectDir`/`resolveGlobalDir` for their subdirectory paths.

**`src/cli/commands/init.ts`**: scaffolds `.agentic/` by default; config template uses `.agentic/` paths.

**`src/hooks/fire.ts`**:
- `hookDirs` resolves via `resolveProjectDir`/`resolveGlobalDir`
- Accepts `AGENTIC_HOOKS_DIR` override (preferred over `SPORES_HOOKS_DIR`)
- `bridgeEnvNames()`: for every `SPORES_*` key in the merged env, adds `AGENTIC_*` mirror and vice versa
- Injects `AGENTIC_EVENT` + `SPORES_EVENT`, `AGENTIC_BIN` + `SPORES_BIN`

## Test plan

- [ ] `bun test` — 473/473 pass
- [ ] `bun run typecheck` — clean
- [ ] New config tests: `.agentic/` loaded, `.agentic/` wins when both exist
- [ ] New hook tests: `AGENTIC_EVENT`/`AGENTIC_BIN` injected, env bridging, `AGENTIC_HOOKS_DIR` override, `.spores/hooks` legacy fallback
- [ ] Existing `.spores/` projects continue working via fallback (no migration required)