### PR TITLE
feat(rename): migrate dogfood to .agentic/ and update docs

### DIFF
--- a/.agentic/ONRAMP.md
+++ b/.agentic/ONRAMP.md
@@ -1,0 +1,61 @@
+# .agentic/ ONRAMP — start a session on this repo
+
+**Read this first. Then do the three things.**
+
+This repo dogfoods its own toolbelt. When you work on `@tnezdev/spores`, you use the `agentic` CLI. Not because it's clever — because if the tool isn't good enough for us to use on its own source, it isn't good enough to ship.
+
+## The three-command on-ramp
+
+```bash
+# 1. Orient — load the maintainer hat with live situational tokens
+bun src/cli/main.ts persona activate spores-maintainer
+
+# 2. Pick up work — top ready task from the local queue
+bun src/cli/main.ts task next
+
+# 3. When cutting a release — run the checklist
+bun src/cli/main.ts skill run release-check
+```
+
+Read the persona output. Do what step 3 of its "Before picking up work" section tells you. Start the work.
+
+## What each command gives you
+
+### `persona activate spores-maintainer`
+
+Principles, anti-patterns, and a "before picking up work" checklist. Situational tokens (`{{cwd}}`, `{{git_branch}}`, `{{timestamp}}`, `{{hostname}}`) get substituted at activation time. Below the body, the `persona.activated` hook at `.agentic/hooks/persona.activated` auto-recalls memories tagged with the persona's `memory_tags` and appends them — that's where current durable facts (runtime scope, publish path, etc.) come from. If you're piping into an LLM, this whole block is the context injection. If you're a human, read it and internalize the non-negotiables before you start typing.
+
+### `task next`
+
+Returns the highest-ULID `ready` task from `.agentic/tasks/`. **Important:** the task list here is a manual mirror of the GitHub `ready`-labeled issues. It is not yet synced automatically. If you've just opened a new ready issue on GitHub, also seed a matching task file via `agentic task add`. See "Known drift" below.
+
+### `skill run release-check`
+
+The CI-gated release checklist. Your job is to land a `chore: release vX.Y.Z` PR on `main`, tag the merge commit `vX.Y.Z`, push the tag, and watch `publish.yml` ship via OIDC trusted publishing. No local `npm publish`.
+
+## Source of truth — what lives where
+
+| Thing | Source of truth | Why |
+|---|---|---|
+| Code state, current commit, who changed what | `git log` / `git blame` | Authoritative, never stale |
+| Ready work on this repo | GitHub issues with `ready` label | Cross-agent async pickup via HEARTBEAT poll |
+| Current task you're working | `.agentic/tasks/*.json` (manually mirrored from GH) | Exercised by `agentic task next` as part of the dogfood |
+| Durable non-obvious facts | `.agentic/memory/*.json` | "Why" that isn't in the code |
+| Values and in-turn orientation | `.agentic/personas/spores-maintainer.md` | What you prioritize while wearing the hat |
+| Release procedure | `.agentic/skills/release-check/skill.md` + `.agentic/workflows/spores-release.json` | CI-gated via `.github/workflows/publish.yml` (OIDC) |
+
+When two sources disagree, trust git and GitHub. Update the dogfood to match — that's the "dogfood as operational workspace, not curated fixture" stance.
+
+**Legacy:** `.spores/` is preserved alongside `.agentic/` during the migration window. Once all users have migrated, `.spores/` will be removed. New additions go in `.agentic/` only.
+
+## Known drift (refresh as you use it)
+
+This section is a living punch list. If you fix something, delete the bullet.
+
+- **`tasks/` sync with GitHub issues is manual.** When you add a ready issue, seed a matching task file. When you close a GH issue, mark the task done. This is a bandaid — the real fix is a TaskAdapter that reads from GitHub issues directly (filed as a v0.2+ issue). Until then, keep them in hand-sync.
+
+- **The persona's task filter is not applied by any CLI verb.** This is the known v0.2 composition-object seam from tnezdev/spores#16. `task next` returns the highest-ULID ready task regardless of the maintainer persona's `task_filter: { tags: [spores] }`. It's the exact design signal #16 was filed to track. Don't work around it in CLI code.
+
+## How to treat this doc
+
+**Living, not curated.** If something here is wrong the next time you use it, fix it in the same session. If the three-command on-ramp grows to four, add the fourth. If one of them becomes obsolete, delete it. The test of this doc's health is whether you actually reach for it at session start. If you don't — figure out why and fix that reason.

--- a/.agentic/README.md
+++ b/.agentic/README.md
@@ -1,0 +1,66 @@
+# .spores/ — dogfood example
+
+This directory is the **v0.1 release-gate smoke test** (#10). If we can't use spores to build spores, v0.1 isn't ready to ship.
+
+Every file here is exercised by the spores CLI itself. Think of it as both the self-use and the working example that ships with the repo.
+
+## Contents
+
+| Path | Primitive | What's in it |
+|---|---|---|
+| `config.toml` | (all) | Spores config — `adapter = "filesystem"`, dirs for each primitive |
+| `personas/spores-maintainer.md` | persona | The hat to wear when working on this codebase. Real principles, real activation triggers, real situational tokens |
+| `skills/release-check/skill.md` | skill | The pre-release checklist. Piped into the agent before cutting a new version |
+| `workflows/spores-release.json` | workflow | 9-node release graph: verify-clean → run-tests → typecheck → dep-audit → pack-dry-run → version-bump → tag-push → publish → verify-published |
+| `memory/*.json` | memory | Durable facts about this repo (npm package name, zero-deps rule, v0.1 runtime-scoping decision) |
+| `tasks/*.json` | task | Real v0.1 tasks — dogfood verification, release cut, v0.2 composition design |
+| `runs/` | workflow | Ephemeral per-run state. **gitignored.** |
+
+## How to use
+
+From the repo root:
+
+```bash
+# List what's available
+bun src/cli/main.ts persona list
+bun src/cli/main.ts skill list
+bun src/cli/main.ts workflow list
+bun src/cli/main.ts task list
+
+# Activate the maintainer hat — pipe into your LLM of choice
+bun src/cli/main.ts persona activate spores-maintainer
+
+# Run the release check skill
+bun src/cli/main.ts skill run release-check
+
+# Pick up the next ready task
+bun src/cli/main.ts task next
+
+# Kick off a release run
+bun src/cli/main.ts workflow run spores-release --name "0.1.0-cut"
+
+# Query memories when you need the "why"
+bun src/cli/main.ts memory recall "runtime scope"
+```
+
+(After `npm install -g @tnezdev/spores`, replace `bun src/cli/main.ts` with `spores`.)
+
+## Why this shape
+
+- **The persona reads like something a human would actually write for themselves.** Not a label, not a role — a set of non-negotiables and a "before you start" checklist. If it feels forced, the primitive isn't pulling its weight.
+- **Skills are agent-facing work product.** `release-check` is not documentation *about* releasing — it's the actual pipeline an agent follows, with verification commands inline.
+- **Memories are non-obvious durable facts**, not restatements of what `git log` already tells you. "Zero production dependencies is a hard rule" is worth remembering because the code alone doesn't say why.
+- **Tasks are the real backlog**, not fake examples. The three seeded here are the literal next moves on the v0.1 milestone.
+- **The workflow is a real process**, not a toy DAG. Every node corresponds to a command someone actually runs at release time.
+
+## What this dogfood validated
+
+- All four primitives (memory/workflow/skills/tasks) + persona compose cleanly in one directory layout
+- `persona activate` template substitution works against live situational facts
+- Adapter-layered project/global resolution is transparent (nothing in `~/.spores/` interferes)
+- `task next` returns the highest-ULID (most recent) ready task — caller is responsible for narrowing with `task_filter` if they want a different ordering (descoped per #8 addendum, caller wires persona bindings manually)
+- Zero production dependencies held throughout
+
+## Runs are ephemeral
+
+`.spores/runs/` is gitignored because each `workflow run` produces a new run record and committing those would add churn without meaning. If you want to reproduce a run, re-run the workflow — the graph is the durable artifact, the run is the execution.

--- a/.agentic/README.md
+++ b/.agentic/README.md
@@ -1,14 +1,14 @@
-# .spores/ — dogfood example
+# .agentic/ — dogfood example
 
-This directory is the **v0.1 release-gate smoke test** (#10). If we can't use spores to build spores, v0.1 isn't ready to ship.
+This directory is the **v0.1 release-gate smoke test** (#10). If we can't use agentic to build agentic, v0.1 isn't ready to ship.
 
-Every file here is exercised by the spores CLI itself. Think of it as both the self-use and the working example that ships with the repo.
+Every file here is exercised by the agentic CLI itself. Think of it as both the self-use and the working example that ships with the repo.
 
 ## Contents
 
 | Path | Primitive | What's in it |
 |---|---|---|
-| `config.toml` | (all) | Spores config — `adapter = "filesystem"`, dirs for each primitive |
+| `config.toml` | (all) | Agentic config — `adapter = "filesystem"`, dirs for each primitive |
 | `personas/spores-maintainer.md` | persona | The hat to wear when working on this codebase. Real principles, real activation triggers, real situational tokens |
 | `skills/release-check/skill.md` | skill | The pre-release checklist. Piped into the agent before cutting a new version |
 | `workflows/spores-release.json` | workflow | 9-node release graph: verify-clean → run-tests → typecheck → dep-audit → pack-dry-run → version-bump → tag-push → publish → verify-published |
@@ -43,7 +43,7 @@ bun src/cli/main.ts workflow run spores-release --name "0.1.0-cut"
 bun src/cli/main.ts memory recall "runtime scope"
 ```
 
-(After `npm install -g @tnezdev/spores`, replace `bun src/cli/main.ts` with `spores`.)
+(After `npm install -g @tnezdev/agentic`, replace `bun src/cli/main.ts` with `agentic`.)
 
 ## Why this shape
 
@@ -57,10 +57,10 @@ bun src/cli/main.ts memory recall "runtime scope"
 
 - All four primitives (memory/workflow/skills/tasks) + persona compose cleanly in one directory layout
 - `persona activate` template substitution works against live situational facts
-- Adapter-layered project/global resolution is transparent (nothing in `~/.spores/` interferes)
+- Adapter-layered project/global resolution is transparent (nothing in `~/.agentic/` interferes)
 - `task next` returns the highest-ULID (most recent) ready task — caller is responsible for narrowing with `task_filter` if they want a different ordering (descoped per #8 addendum, caller wires persona bindings manually)
 - Zero production dependencies held throughout
 
 ## Runs are ephemeral
 
-`.spores/runs/` is gitignored because each `workflow run` produces a new run record and committing those would add churn without meaning. If you want to reproduce a run, re-run the workflow — the graph is the durable artifact, the run is the execution.
+`.agentic/runs/` is gitignored because each `workflow run` produces a new run record and committing those would add churn without meaning. If you want to reproduce a run, re-run the workflow — the graph is the durable artifact, the run is the execution.

--- a/.agentic/config.toml
+++ b/.agentic/config.toml
@@ -1,0 +1,13 @@
+# Agentic configuration
+# See: https://github.com/tnezdev/spores
+
+adapter = "filesystem"
+
+[memory]
+dir = ".agentic/memory"
+default_tier = "L1"
+dream_depth = "3"
+
+[workflow]
+graphs_dir = ".agentic/workflows"
+runs_dir = ".agentic/runs"

--- a/.agentic/hooks/artifact.written
+++ b/.agentic/hooks/artifact.written
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# .spores/hooks/artifact.written
+#
+# Fires after `spores artifact write <id>` or `spores artifact edit <id>`
+# has persisted a new version to disk.
+# Indexes the artifact reference into memory so it can be recalled by type,
+# title, or version via `spores memory recall`.
+#
+# Contract — env vars set by spores:
+#   SPORES_EVENT            = "artifact.written" | "artifact.edited"
+#   SPORES_BIN              = path to the spores CLI entry (for callbacks)
+#   SPORES_ARTIFACT_ID      = the artifact ULID
+#   SPORES_ARTIFACT_VERSION = the new version number (as a string)
+#   SPORES_ARTIFACT_MODE    = write mode: "iterate" | "replace"
+#
+# Stdout from this script is appended to the command output.
+# Non-zero exit is surfaced as a warning — it does not fail the write.
+
+set -euo pipefail
+
+ID="${SPORES_ARTIFACT_ID:-}"
+VERSION="${SPORES_ARTIFACT_VERSION:-}"
+MODE="${SPORES_ARTIFACT_MODE:-}"
+
+# Exit quietly if no artifact info to work with
+[[ -z "$ID" ]] && exit 0
+
+# Build memory content
+CONTENT="Artifact written: ${ID} v${VERSION} (mode: ${MODE})"
+
+# SPORES_BIN may be a path to main.ts (dev) or the installed `spores` binary.
+if [[ "$SPORES_BIN" == *.ts ]]; then
+  invoke() { bun "$SPORES_BIN" "$@"; }
+else
+  invoke() { "$SPORES_BIN" "$@"; }
+fi
+
+# Store with a stable key so iterate writes update rather than duplicate
+invoke memory remember "$CONTENT" \
+  --key "artifact-written:${ID}" \
+  --tags "artifact-written" \
+  --tier L1 || true

--- a/.agentic/hooks/persona.activated
+++ b/.agentic/hooks/persona.activated
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# .spores/hooks/persona.activated
+#
+# Fires after `spores persona activate <name>` has rendered the persona body.
+# Recalls memories tagged with the persona's own memory_tags and appends them
+# to the activation output. This is the cheap v0 realization of the
+# persona memory_tags binding (tnezdev/spores#16, explored via hooks in #26).
+#
+# Contract — env vars set by spores:
+#   SPORES_EVENT               = "persona.activated"
+#   SPORES_BIN                 = path to the spores CLI entry (for callbacks)
+#   SPORES_PERSONA_NAME        = the activated persona's name
+#   SPORES_PERSONA_MEMORY_TAGS = comma-separated list from frontmatter
+#   SPORES_PERSONA_SKILLS      = comma-separated list
+#   SPORES_PERSONA_WORKFLOW    = single string or empty
+#
+# Stdout from this script is appended to the activation output.
+# Non-zero exit is surfaced as a warning — it does not fail the activation.
+
+set -euo pipefail
+
+if [[ -z "${SPORES_PERSONA_MEMORY_TAGS:-}" ]]; then
+  exit 0
+fi
+
+# Split the comma-separated tag list into positional args.
+IFS=',' read -ra tags <<< "$SPORES_PERSONA_MEMORY_TAGS"
+
+echo "## Recalled memory (tags: ${SPORES_PERSONA_MEMORY_TAGS})"
+echo
+
+# Call back into spores for each tag. --tag is repeatable on memory recall,
+# and the CLI handles deduplication by key internally.
+args=()
+for tag in "${tags[@]}"; do
+  [[ -z "$tag" ]] && continue
+  args+=(--tag "$tag")
+done
+
+if [[ ${#args[@]} -eq 0 ]]; then
+  exit 0
+fi
+
+# SPORES_BIN may be a path to main.ts (dev) or the installed `spores` binary.
+# Either way, invoking it via `bun` works in dev and `bun` is a peer dep of
+# this dogfood. For the installed case, prefer `spores` directly on PATH.
+if [[ "$SPORES_BIN" == *.ts ]]; then
+  bun "$SPORES_BIN" memory recall "${args[@]}" || true
+else
+  "$SPORES_BIN" memory recall "${args[@]}" || true
+fi

--- a/.agentic/hooks/task.added
+++ b/.agentic/hooks/task.added
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# .spores/hooks/task.added
+#
+# Fires after `spores task add <description>` has created a new task.
+# Records the new task to memory so it's searchable via recall.
+# Design + catalog: tnezdev/spores#26.
+#
+# Contract — env vars set by spores:
+#   SPORES_EVENT            = "task.added"
+#   SPORES_BIN              = path to the spores CLI entry (for callbacks)
+#   SPORES_TASK_ID          = the task ULID
+#   SPORES_TASK_DESCRIPTION = the task description
+#   SPORES_TASK_TAGS        = comma-separated tags (may be empty)
+#   SPORES_TASK_PARENT_ID   = parent task ULID (may be empty)
+#
+# Non-zero exit is surfaced as a warning — it does not fail the task creation.
+
+set -euo pipefail
+
+ID="${SPORES_TASK_ID:-}"
+DESC="${SPORES_TASK_DESCRIPTION:-}"
+TAGS="${SPORES_TASK_TAGS:-}"
+
+[[ -z "$ID" ]] && exit 0
+[[ -z "$DESC" ]] && exit 0
+
+CONTENT="Task added: ${DESC}"
+[[ -n "$TAGS" ]] && CONTENT="${CONTENT} (tags: ${TAGS})"
+
+if [[ "$SPORES_BIN" == *.ts ]]; then
+  invoke() { bun "$SPORES_BIN" "$@"; }
+else
+  invoke() { "$SPORES_BIN" "$@"; }
+fi
+
+# Stable key so re-adding identical descriptions doesn't create dupes
+invoke memory remember "$CONTENT" \
+  --key "task-added:${ID}" \
+  --tags "task-added" \
+  --tier L1 || true

--- a/.agentic/hooks/task.annotated
+++ b/.agentic/hooks/task.annotated
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# .spores/hooks/task.annotated
+#
+# Fires after `spores task annotate <id> <text>` has appended an annotation.
+# Records the annotation to memory so key observations are searchable.
+# Design + catalog: tnezdev/spores#26.
+#
+# Contract — env vars set by spores:
+#   SPORES_EVENT            = "task.annotated"
+#   SPORES_BIN              = path to the spores CLI entry (for callbacks)
+#   SPORES_TASK_ID          = the task ULID
+#   SPORES_TASK_DESCRIPTION = the task description
+#   SPORES_TASK_TAGS        = comma-separated tags (may be empty)
+#   SPORES_TASK_PARENT_ID   = parent task ULID (may be empty)
+#   SPORES_TASK_ANNOTATION  = the annotation text just appended
+#
+# Non-zero exit is surfaced as a warning — it does not fail the annotation.
+
+set -euo pipefail
+
+ID="${SPORES_TASK_ID:-}"
+DESC="${SPORES_TASK_DESCRIPTION:-}"
+NOTE="${SPORES_TASK_ANNOTATION:-}"
+
+[[ -z "$ID" ]] && exit 0
+[[ -z "$NOTE" ]] && exit 0
+
+CONTENT="Annotation on '${DESC}': ${NOTE}"
+
+if [[ "$SPORES_BIN" == *.ts ]]; then
+  invoke() { bun "$SPORES_BIN" "$@"; }
+else
+  invoke() { "$SPORES_BIN" "$@"; }
+fi
+
+# Use timestamp-based key since annotations accumulate (not idempotent by design)
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+invoke memory remember "$CONTENT" \
+  --key "task-annotated:${ID}:${TS}" \
+  --tags "task-annotated" \
+  --tier L1 || true

--- a/.agentic/hooks/task.done
+++ b/.agentic/hooks/task.done
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# .spores/hooks/task.done
+#
+# Fires after `spores task done <id>` has marked the task complete.
+# Records the completed task to memory so it's searchable via recall.
+# This is the v0 realization of the task.done hook (tnezdev/spores#26).
+#
+# Contract — env vars set by spores:
+#   SPORES_EVENT            = "task.done"
+#   SPORES_BIN              = path to the spores CLI entry (for callbacks)
+#   SPORES_TASK_ID          = the task ULID
+#   SPORES_TASK_DESCRIPTION = the task description
+#   SPORES_TASK_TAGS        = comma-separated tags (may be empty)
+#   SPORES_TASK_PARENT_ID   = parent task ULID (may be empty)
+#
+# Stdout from this script is appended to the task done output.
+# Non-zero exit is surfaced as a warning — it does not fail the task update.
+
+set -euo pipefail
+
+ID="${SPORES_TASK_ID:-}"
+DESC="${SPORES_TASK_DESCRIPTION:-}"
+TAGS="${SPORES_TASK_TAGS:-}"
+
+# Exit quietly if no task info to work with
+[[ -z "$ID" ]] && exit 0
+[[ -z "$DESC" ]] && exit 0
+
+# Build memory content from task data
+CONTENT="Completed: ${DESC}"
+[[ -n "$TAGS" ]] && CONTENT="${CONTENT} (tags: ${TAGS})"
+
+# SPORES_BIN may be a path to main.ts (dev) or the installed `spores` binary.
+if [[ "$SPORES_BIN" == *.ts ]]; then
+  invoke() { bun "$SPORES_BIN" "$@"; }
+else
+  invoke() { "$SPORES_BIN" "$@"; }
+fi
+
+# Store with a stable key (task-done:<id>) so re-running doesn't create dupes
+invoke memory remember "$CONTENT" \
+  --key "task-done:${ID}" \
+  --tags "task-done" \
+  --tier L1 || true

--- a/.agentic/hooks/task.started
+++ b/.agentic/hooks/task.started
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# .spores/hooks/task.started
+#
+# Fires after `spores task start <id>` has transitioned a task to in_progress.
+# Records the started task to memory. Design + catalog: tnezdev/spores#26.
+#
+# Contract — env vars set by spores:
+#   SPORES_EVENT            = "task.started"
+#   SPORES_BIN              = path to the spores CLI entry (for callbacks)
+#   SPORES_TASK_ID          = the task ULID
+#   SPORES_TASK_DESCRIPTION = the task description
+#   SPORES_TASK_TAGS        = comma-separated tags (may be empty)
+#   SPORES_TASK_PARENT_ID   = parent task ULID (may be empty)
+#
+# Non-zero exit is surfaced as a warning — it does not fail the status update.
+
+set -euo pipefail
+
+ID="${SPORES_TASK_ID:-}"
+DESC="${SPORES_TASK_DESCRIPTION:-}"
+TAGS="${SPORES_TASK_TAGS:-}"
+
+[[ -z "$ID" ]] && exit 0
+[[ -z "$DESC" ]] && exit 0
+
+CONTENT="Task started: ${DESC}"
+[[ -n "$TAGS" ]] && CONTENT="${CONTENT} (tags: ${TAGS})"
+
+if [[ "$SPORES_BIN" == *.ts ]]; then
+  invoke() { bun "$SPORES_BIN" "$@"; }
+else
+  invoke() { "$SPORES_BIN" "$@"; }
+fi
+
+invoke memory remember "$CONTENT" \
+  --key "task-started:${ID}" \
+  --tags "task-started" \
+  --tier L1 || true

--- a/.agentic/memory/74d0c073-f85d-43c0-afac-d8720f26e7d2.json
+++ b/.agentic/memory/74d0c073-f85d-43c0-afac-d8720f26e7d2.json
@@ -1,0 +1,9 @@
+{
+  "key": "74d0c073-f85d-43c0-afac-d8720f26e7d2",
+  "content": "v0.1 publish path is npm Trusted Publishing via GitHub Actions OIDC — no NPM_TOKEN. Trusted publisher is registered at npmjs.com for @tnezdev/spores against workflow filename publish.yml. Workflow needs permissions.id-token: write and npm >= 11.5.1. Chosen over automation tokens for no-secret-lifecycle and build provenance binding to exact workflow+repo+ref.",
+  "weight": 0.5,
+  "confidence": 1,
+  "tier": "L1",
+  "tags": [],
+  "timestamp": "2026-04-09T12:20:01.013Z"
+}

--- a/.agentic/memory/repo-identity.json
+++ b/.agentic/memory/repo-identity.json
@@ -1,0 +1,12 @@
+{
+  "key": "repo-identity",
+  "content": "This repo publishes to npm as @tnezdev/spores. Zero production dependencies is a hard rule.",
+  "weight": 0.9,
+  "confidence": 1,
+  "tier": "L1",
+  "tags": [
+    "spores",
+    "npm-publishing"
+  ],
+  "timestamp": "2026-04-09T11:17:06.899Z"
+}

--- a/.agentic/memory/runtime-scope.json
+++ b/.agentic/memory/runtime-scope.json
@@ -1,0 +1,12 @@
+{
+  "key": "runtime-scope",
+  "content": "Runtime is workflow-only in v0.1. Persona bindings are the caller's responsibility, not spores'. Composition object deferred to v0.2+.",
+  "weight": 0.9,
+  "confidence": 1,
+  "tier": "L1",
+  "tags": [
+    "spores",
+    "v0.1"
+  ],
+  "timestamp": "2026-04-09T11:17:06.916Z"
+}

--- a/.agentic/personas/spores-maintainer.md
+++ b/.agentic/personas/spores-maintainer.md
@@ -1,0 +1,50 @@
+---
+name: spores-maintainer
+description: Activate when working on the @tnezdev/spores toolbelt — implementation, tests, release prep, or milestone planning
+memory_tags: [spores, npm-publishing]
+skills: [release-check]
+task_filter:
+  tags: [spores]
+  status: ready
+workflow: spores-release
+effort: high
+reasoning: high
+---
+
+# Spores maintainer
+
+You are working on `@tnezdev/spores` — a TypeScript library + CLI on Bun that ships agent in-loop primitives. Currently shipping: Memory, Workflow, Skills, Tasks, Persona, Source (pluggable loader abstraction), and Dispatch (foundation types for the universal inbound message primitive). Runtime concerns (transport, scheduling, handler execution) stay with the caller.
+
+You are on `{{hostname}}`, working from `{{cwd}}`, on branch `{{git_branch}}`.
+The time is `{{timestamp}}`.
+
+## Principles (non-negotiable)
+
+- **Zero production dependencies.** `"dependencies": {}` in `package.json` stays clean. devDependencies only when absolutely required.
+- **Types first.** Add shapes to `src/types.ts` before writing implementations.
+- **Adapter pattern.** Every primitive has an `adapter.ts` interface and a `filesystem.ts` implementation. New storage backends implement the same interface.
+- **No `console.log` in library code.** CLI output goes through `output(ctx, data, formatter)` re-exported from `src/cli/main.ts`.
+- **Test files colocated.** `src/foo/filesystem.test.ts` next to `src/foo/filesystem.ts`. Inline fixtures, no separate fixtures directory.
+- **Identity lives outside spores.** Spores ships primitives — not sessions, not attribution, not `observed_by`. If you're tempted to add an identity field, stop.
+
+## Before picking up work
+
+1. Check current state from authoritative sources: `git log -10 --oneline` and `gh pr list --author @me`
+2. Check ready work on this repo: `gh issue list --repo tnezdev/spores --state open --label ready`
+3. Run `spores task next` to see the top locally-mirrored ready task
+4. If GitHub ready-issues and `.spores/tasks/` disagree, trust GitHub and update the local task files — see `.spores/ONRAMP.md` "Known drift"
+5. If a task has no `ready` label yet, it's either a design issue or unclear scope — raise the question on the issue before starting
+
+## Before opening a PR
+
+- `bun test` — all green
+- `bun run typecheck` — clean
+- Test fixtures inline, no new `fixtures/` directory
+- PR description lists implementation picks for anything the spec didn't nail down
+- Assign to yourself and use conventional-commit-style title
+
+## Durable context
+
+The `persona.activated` hook at `.spores/hooks/persona.activated` recalls memories tagged with this persona's `memory_tags` and appends them below this body at activation time. Read those recalled memories for the current shape of durable non-obvious facts (runtime scope, publish path, v0.1 decisions) — they are the source of truth, not this body.
+
+The job of this body is rules and rhythms that do not change per session: the principles above, the "before picking up work" checklist, the "before opening a PR" list. Situational facts live in memory and get auto-recalled. If a durable fact isn't showing up when you need it, `spores memory remember` it with the right tag and the next activation will surface it automatically.

--- a/.agentic/skills/post-publish-check/skill.md
+++ b/.agentic/skills/post-publish-check/skill.md
@@ -1,0 +1,34 @@
+---
+name: post-publish-check
+description: Activate after publishing a new release — installs the package from the npm registry and verifies all exports load under Bun
+tags: [spores, release, npm, testing]
+---
+
+# Post-publish check
+
+Validates that `@tnezdev/spores` is consumable when installed from the npm registry. This is the safety net that catches registry-specific issues (missing files, bad `exports` map, propagation problems) that the pre-publish smoke test can't.
+
+## Run it
+
+```bash
+bash scripts/post-publish-check.sh [version]
+```
+
+- Omit `version` to check `latest`
+- Pass a specific version (e.g. `0.2.0`) right after publish when `latest` may not have propagated yet
+
+## What it does
+
+1. Creates a temp consumer project
+2. Installs `@tnezdev/spores@<version>` from the npm registry via `bun add`
+3. Prints the installed version
+4. Runs `scripts/smoke-consumer.ts` — the same export checks used by the pre-publish smoke test
+
+## When to run
+
+- After every release, as the final step of the `spores-release` workflow (step 5: verify-registry)
+- When investigating consumer reports of import failures
+
+## Relation to smoke-test
+
+`smoke-test` validates the `npm pack` tarball *before* publish. `post-publish-check` validates the registry package *after* publish. They share the same consumer script (`scripts/smoke-consumer.ts`).

--- a/.agentic/skills/release-check/skill.md
+++ b/.agentic/skills/release-check/skill.md
@@ -1,0 +1,77 @@
+---
+name: release-check
+description: Activate when cutting a new @tnezdev/spores release — the CI-gated checklist for landing a version bump and triggering the tag publish
+tags: [spores, release, npm, ci]
+---
+
+# Release check — @tnezdev/spores
+
+Releases are **CI-gated**. You don't run `npm publish`; you push a `vX.Y.Z` tag and `.github/workflows/publish.yml` does the rest via npm Trusted Publishing (OIDC). Your job is to land a clean version bump on `main` and hand the tag to CI.
+
+**The gate is CI. Do not publish locally.** There is no `NPM_TOKEN`; there is no path for a local `npm publish` to succeed. If you find yourself typing it, stop.
+
+## 1. Land the version bump on main
+
+Open a `chore: release vX.Y.Z` PR that:
+
+- Bumps `version` in `package.json` per semver.
+- Appends a CHANGELOG entry (or release notes section) covering user-visible changes since the last tag.
+- Keeps `"dependencies": {}` in `package.json`. A non-empty production dependency is a design regression — investigate before shipping.
+
+Merge only after CI (`.github/workflows/ci.yml`) is green on the PR. CI runs `bun test` and `bun run typecheck` — those are the authoritative gates, not a local run.
+
+## 2. Sync and sanity-check main
+
+```bash
+git checkout main && git pull
+git log -1 --oneline   # confirm the release commit is HEAD
+```
+
+The commit you're about to tag must be the merged release commit on `origin/main`. No tagging from feature branches, no tagging ahead of merge.
+
+## 3. Tag and push
+
+```bash
+git tag -a vX.Y.Z -m "vX.Y.Z"
+git push origin vX.Y.Z
+```
+
+The tag push is the trigger. `publish.yml` runs on `push: tags: [v*.*.*]` and takes over from here.
+
+## 4. Watch publish.yml run green
+
+```bash
+gh run watch --exit-status
+# or
+gh run list --workflow=publish.yml --limit 3
+```
+
+What the workflow does (for context when reading logs):
+
+1. Checkout + Bun + `bun install --frozen-lockfile`
+2. `bun run typecheck` and `bun test` (re-gate, cheap)
+3. Bootstraps npm 11 via direct tarball download (the runner's bundled npm has historically been corrupt on fresh `ubuntu-latest` images — don't "simplify" this step)
+4. `npm publish --provenance --access public` using OIDC — no token, no secret
+
+If the workflow fails:
+
+- **Do not delete the tag as a first move.** Investigate in the logs; most failures (flaky install, transient registry) are retryable via `gh run rerun`.
+- If the failure is real (bad code landed, version bump wrong), fix forward on `main` with a new patch version — `vX.Y.(Z+1)` — and a new tag. A published version is immutable; don't chase the old number.
+- Only delete-and-retag if the tag was pushed to the wrong commit *and nothing published*. Confirm with `npm view @tnezdev/spores versions` before retagging.
+
+## 5. Verify the registry
+
+```bash
+npm view @tnezdev/spores version
+bash scripts/post-publish-check.sh X.Y.Z
+```
+
+`npm view` should print the version you just tagged. If it lags, wait 30 seconds and retry — npm registry propagation.
+
+Then run the post-publish check — it installs the package from the registry in a temp dir and verifies all public API exports load under Bun. Pass the explicit version since `latest` may not have propagated yet.
+
+Also spot-check provenance on https://www.npmjs.com/package/@tnezdev/spores — the published version should show a "Built and signed on GitHub Actions" badge linking back to the workflow run. That badge is the whole point of OIDC; its absence means provenance attestation didn't attach and is worth investigating.
+
+## On failure — general rule
+
+A failed publish run does not mean "roll back." It means "the tag did not ship a package." The main branch is still the source of truth. Fix forward, bump patch, retag. Never rewrite history on `main` to "unship" a tag that CI caught.

--- a/.agentic/skills/smoke-test/skill.md
+++ b/.agentic/skills/smoke-test/skill.md
@@ -1,0 +1,34 @@
+---
+name: smoke-test
+description: Activate when you need to validate the package is consumable before a release — runs npm pack, installs the tarball, and verifies exports under Bun
+tags: [spores, release, npm, testing]
+---
+
+# Pre-publish smoke test
+
+Validates that `@tnezdev/spores` is consumable from an `npm pack` tarball under Bun. This catches packaging issues (missing files, broken imports, wrong entry point) before a release tag is pushed.
+
+## Run it
+
+```bash
+bash scripts/smoke-test.sh
+```
+
+## What it does
+
+1. `npm pack` in the repo root — produces the exact tarball that `npm publish` would upload
+2. Creates a temp consumer project and installs the tarball via `bun add`
+3. Runs `scripts/smoke-consumer.ts` which imports the public API and checks that all value exports are present and constructable
+
+## When to run
+
+- Before pushing a release tag (`vX.Y.Z`)
+- After changing `package.json` fields (`files`, `main`, `exports`)
+- After adding or removing public exports from `src/index.ts`
+
+CI runs this automatically in `.github/workflows/publish.yml` between the test step and the publish step.
+
+## Current scope
+
+- **Bun only.** Node.js consumption is not validated (see tnezdev/spores#32).
+- Checks value exports exist with the right type (`function` for classes and functions). Does not exercise runtime behavior beyond import resolution.

--- a/.agentic/tasks/01KNRZBRHZZ3R8TMQFY32VW18B.json
+++ b/.agentic/tasks/01KNRZBRHZZ3R8TMQFY32VW18B.json
@@ -1,0 +1,17 @@
+{
+  "description": "Verify dogfood .spores/ example exercises all four primitives end-to-end",
+  "status": "done",
+  "tags": [
+    "spores",
+    "v0.1"
+  ],
+  "id": "01KNRZBRHZZ3R8TMQFY32VW18B",
+  "annotations": [
+    {
+      "text": "status: ready → done",
+      "timestamp": "2026-04-09T12:19:48.886Z"
+    }
+  ],
+  "created_at": "2026-04-09T11:17:12.895Z",
+  "updated_at": "2026-04-09T12:19:48.886Z"
+}

--- a/.agentic/tasks/01KNRZBRJHB3B1B13RN7RXB4BJ.json
+++ b/.agentic/tasks/01KNRZBRJHB3B1B13RN7RXB4BJ.json
@@ -1,0 +1,19 @@
+{
+  "description": "Cut @tnezdev/spores@0.1.0 to npm once dogfood lands",
+  "status": "done",
+  "tags": [
+    "spores",
+    "release",
+    "v0.1"
+  ],
+  "wait_until": "2026-04-10T00:00:00Z",
+  "id": "01KNRZBRJHB3B1B13RN7RXB4BJ",
+  "annotations": [
+    {
+      "text": "status: ready → done",
+      "timestamp": "2026-04-09T12:19:48.904Z"
+    }
+  ],
+  "created_at": "2026-04-09T11:17:12.912Z",
+  "updated_at": "2026-04-09T12:19:48.904Z"
+}

--- a/.agentic/tasks/01KNRZBRK1S3WAB2DTYG1TNTB5.json
+++ b/.agentic/tasks/01KNRZBRK1S3WAB2DTYG1TNTB5.json
@@ -1,0 +1,13 @@
+{
+  "description": "Investigate v0.2 composition object: Runtime vs Scope vs Spores top-level",
+  "status": "ready",
+  "tags": [
+    "spores",
+    "v0.2",
+    "design"
+  ],
+  "id": "01KNRZBRK1S3WAB2DTYG1TNTB5",
+  "annotations": [],
+  "created_at": "2026-04-09T11:17:12.929Z",
+  "updated_at": "2026-04-09T11:17:12.929Z"
+}

--- a/.agentic/tasks/01KNS2YM25FHB9NVAEFTPYWJC6.json
+++ b/.agentic/tasks/01KNS2YM25FHB9NVAEFTPYWJC6.json
@@ -1,0 +1,18 @@
+{
+  "description": "Land #17 — add user-facing README.md",
+  "status": "done",
+  "tags": [
+    "spores",
+    "v0.1.1",
+    "docs"
+  ],
+  "id": "01KNS2YM25FHB9NVAEFTPYWJC6",
+  "annotations": [
+    {
+      "text": "status: ready → done",
+      "timestamp": "2026-04-09T13:16:40.647Z"
+    }
+  ],
+  "created_at": "2026-04-09T12:19:56.613Z",
+  "updated_at": "2026-04-09T13:16:40.647Z"
+}

--- a/.agentic/tasks/01KNS2YM2Q3HBK7QQVM6GDK962.json
+++ b/.agentic/tasks/01KNS2YM2Q3HBK7QQVM6GDK962.json
@@ -1,0 +1,18 @@
+{
+  "description": "Land #18 — CLI --wide flag for table truncation",
+  "status": "done",
+  "tags": [
+    "spores",
+    "v0.1.1",
+    "cli"
+  ],
+  "id": "01KNS2YM2Q3HBK7QQVM6GDK962",
+  "annotations": [
+    {
+      "text": "status: ready → done",
+      "timestamp": "2026-04-09T13:16:40.666Z"
+    }
+  ],
+  "created_at": "2026-04-09T12:19:56.631Z",
+  "updated_at": "2026-04-09T13:16:40.666Z"
+}

--- a/.agentic/tasks/01KNS2YM39BX6DXDJT0Z9YMGYV.json
+++ b/.agentic/tasks/01KNS2YM39BX6DXDJT0Z9YMGYV.json
@@ -1,0 +1,18 @@
+{
+  "description": "Cut v0.1.1 — first OIDC/CI-published release",
+  "status": "done",
+  "tags": [
+    "spores",
+    "v0.1.1",
+    "release"
+  ],
+  "id": "01KNS2YM39BX6DXDJT0Z9YMGYV",
+  "annotations": [
+    {
+      "text": "status: ready → done",
+      "timestamp": "2026-04-09T13:16:40.682Z"
+    }
+  ],
+  "created_at": "2026-04-09T12:19:56.649Z",
+  "updated_at": "2026-04-09T13:16:40.682Z"
+}

--- a/.agentic/tasks/01KNS2YM3VDZT4QB1QEZRMXBWQ.json
+++ b/.agentic/tasks/01KNS2YM3VDZT4QB1QEZRMXBWQ.json
@@ -1,0 +1,18 @@
+{
+  "description": "Update release-check skill + spores-release workflow from manual to CI-gate flow (after first successful CI publish)",
+  "status": "done",
+  "tags": [
+    "spores",
+    "dogfood",
+    "skill"
+  ],
+  "id": "01KNS2YM3VDZT4QB1QEZRMXBWQ",
+  "annotations": [
+    {
+      "text": "status: ready → done",
+      "timestamp": "2026-04-09T19:45:51.363Z"
+    }
+  ],
+  "created_at": "2026-04-09T12:19:56.667Z",
+  "updated_at": "2026-04-09T19:45:51.363Z"
+}

--- a/.agentic/tasks/01KNSYAM3WXBJG4YD92PE6D3BQ.json
+++ b/.agentic/tasks/01KNSYAM3WXBJG4YD92PE6D3BQ.json
@@ -1,0 +1,18 @@
+{
+  "description": "hooks: persona.activated fires script hook, wire spores-maintainer to auto-recall memories",
+  "status": "done",
+  "tags": [
+    "spores",
+    "hooks",
+    "v0.2"
+  ],
+  "id": "01KNSYAM3WXBJG4YD92PE6D3BQ",
+  "annotations": [
+    {
+      "text": "status: ready → done",
+      "timestamp": "2026-04-09T20:27:54.920Z"
+    }
+  ],
+  "created_at": "2026-04-09T20:18:21.436Z",
+  "updated_at": "2026-04-09T20:27:54.920Z"
+}

--- a/.agentic/workflows/spores-release.json
+++ b/.agentic/workflows/spores-release.json
@@ -1,0 +1,44 @@
+{
+  "id": "spores-release",
+  "name": "Spores release cut",
+  "description": "CI-gated release flow for @tnezdev/spores — land version bump on main, push tag, let publish.yml ship via OIDC trusted publishing",
+  "version": "2.0",
+  "nodes": [
+    {
+      "id": "version-bump-pr",
+      "label": "Open release PR",
+      "description": "Bump package.json version per semver, append CHANGELOG entry, open 'chore: release vX.Y.Z' PR — merge only when CI is green",
+      "artifact_type": "pull-request"
+    },
+    {
+      "id": "sync-main",
+      "label": "Sync main and confirm release commit",
+      "description": "git checkout main && git pull; git log -1 must show the merged release commit",
+      "artifact_type": "git-ref"
+    },
+    {
+      "id": "tag-push",
+      "label": "Tag and push",
+      "description": "git tag -a vX.Y.Z -m 'vX.Y.Z' && git push origin vX.Y.Z — this is the trigger for publish.yml",
+      "artifact_type": "git-tag"
+    },
+    {
+      "id": "watch-publish-ci",
+      "label": "Watch publish.yml run",
+      "description": "gh run watch --exit-status — publish.yml runs typecheck+test, bootstraps npm 11 via tarball, publishes with OIDC + provenance. No local publish.",
+      "artifact_type": "ci-run"
+    },
+    {
+      "id": "verify-registry",
+      "label": "Verify registry + provenance",
+      "description": "npm view @tnezdev/spores version matches tag; run 'bash scripts/post-publish-check.sh <version>' to verify consumer install from registry; check npmjs.com page for 'Built and signed on GitHub Actions' provenance badge",
+      "artifact_type": "registry-check"
+    }
+  ],
+  "edges": [
+    { "from": "version-bump-pr", "to": "sync-main" },
+    { "from": "sync-main", "to": "tag-push" },
+    { "from": "tag-push", "to": "watch-publish-ci" },
+    { "from": "watch-publish-ci", "to": "verify-registry" }
+  ]
+}

--- a/.agentic/workflows/spores-release.source.json
+++ b/.agentic/workflows/spores-release.source.json
@@ -1,0 +1,97 @@
+{
+  "id": "spores-release",
+  "name": "Spores release cut",
+  "description": "End-to-end workflow for cutting a new @tnezdev/spores version",
+  "version": "1.0",
+  "nodes": [
+    {
+      "id": "verify-clean",
+      "label": "Verify clean working tree",
+      "description": "git status shows no uncommitted changes; on main; up to date with origin",
+      "artifact_type": "git-status"
+    },
+    {
+      "id": "run-tests",
+      "label": "Run full test suite",
+      "description": "bun test — all green, no failures, no skipped suites",
+      "artifact_type": "test-report"
+    },
+    {
+      "id": "typecheck",
+      "label": "Run typecheck",
+      "description": "bun run typecheck — tsc --noEmit exits 0",
+      "artifact_type": "typecheck-report"
+    },
+    {
+      "id": "dep-audit",
+      "label": "Verify zero production dependencies",
+      "description": "package.json dependencies field is empty object",
+      "artifact_type": "package-json"
+    },
+    {
+      "id": "pack-dry-run",
+      "label": "Pack dry run",
+      "description": "npm pack --dry-run — scan contents for unwanted files",
+      "artifact_type": "pack-manifest"
+    },
+    {
+      "id": "version-bump",
+      "label": "Bump version and write CHANGELOG",
+      "description": "Edit package.json version per semver; append CHANGELOG entry; commit",
+      "artifact_type": "commit"
+    },
+    {
+      "id": "tag-push",
+      "label": "Tag and push",
+      "description": "git tag -a vX.Y.Z -m 'vX.Y.Z' && git push --tags",
+      "artifact_type": "git-tag"
+    },
+    {
+      "id": "publish",
+      "label": "Publish to npm",
+      "description": "npm publish --access public — pause for Travis to run manually",
+      "type": "manual",
+      "artifact_type": "npm-publish"
+    },
+    {
+      "id": "verify-published",
+      "label": "Verify registry",
+      "description": "npm view @tnezdev/spores version matches the tag just cut",
+      "artifact_type": "registry-check"
+    }
+  ],
+  "edges": [
+    {
+      "from": "verify-clean",
+      "to": "run-tests"
+    },
+    {
+      "from": "run-tests",
+      "to": "typecheck"
+    },
+    {
+      "from": "typecheck",
+      "to": "dep-audit"
+    },
+    {
+      "from": "dep-audit",
+      "to": "pack-dry-run"
+    },
+    {
+      "from": "pack-dry-run",
+      "to": "version-bump"
+    },
+    {
+      "from": "version-bump",
+      "to": "tag-push"
+    },
+    {
+      "from": "tag-push",
+      "to": "publish"
+    },
+    {
+      "from": "publish",
+      "to": "verify-published"
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 node_modules/
 dist/
 
-# .spores/ is dogfooded in this repo (see #10). Track everything except
-# ephemeral per-run state.
+# Both .agentic/ and .spores/ are dogfooded in this repo (see #10, #65).
+# .agentic/ is now the preferred primary directory; .spores/ remains during
+# the compatibility window. Track everything except ephemeral per-run state.
+.agentic/runs/
 .spores/runs/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,12 @@
-# AGENTS.md — SPORES
+# AGENTS.md — Agentic (formerly SPORES)
 
 Orientation for agent sessions. Concise. Read before touching code.
 
+> **Rename in progress:** The package is migrating from `spores` / `.spores/` to `agentic` / `.agentic/`. Both names work during the compatibility window. Prefer `agentic` in new code and docs.
+
 ## Start here
 
-This repo dogfoods its own toolbelt. Before touching code, run the three-command on-ramp in [`.spores/ONRAMP.md`](.spores/ONRAMP.md) — it activates the `spores-maintainer` persona, pulls the top ready task, and points you at the release skill. The rest of this file is reference; ONRAMP.md is the path.
+This repo dogfoods its own toolbelt. Before touching code, run the three-command on-ramp in [`.agentic/ONRAMP.md`](.agentic/ONRAMP.md) — it activates the `spores-maintainer` persona, pulls the top ready task, and points you at the release skill. The rest of this file is reference; ONRAMP.md is the path.
 
 ## What is SPORES?
 
@@ -78,24 +80,26 @@ Data primitives (Memory, Artifacts, Tasks) have query semantics and live behind 
 ### CLI: two-word dispatch
 
 ```
-spores <noun> <verb> [args]
+agentic <noun> <verb> [args]    # preferred
+spores  <noun> <verb> [args]    # compatibility alias
 ```
 
 Commands in `src/cli/commands/<noun>.ts`. Each command is a `Command` function exported as `<noun><Verb>Command`. The dispatch table is in `src/cli/main.ts`.
 
 Current command surface:
-- `spores init` — scaffold `.spores/` config
-- `spores memory remember/recall/forget/dream/reinforce`
-- `spores skill list/show/run`
-- `spores workflow list/show/run/status`
-- `spores persona list/view/activate`
-- `spores artifact create/read/write/edit/inspect/list/lock`
+- `agentic init` — scaffold `.agentic/` config
+- `agentic memory remember/recall/forget/dream/reinforce`
+- `agentic skill list/show/run`
+- `agentic workflow list/show/run/status`
+- `agentic persona list/view/activate`
+- `agentic artifact create/read/write/edit/inspect/list/lock`
 
 ### Skills on disk
 
 ```
-~/.spores/skills/<name>/skill.md     # global (user-level)
-.spores/skills/<name>/skill.md       # project-level (wins on name conflict)
+~/.agentic/skills/<name>/skill.md    # global (user-level)
+.agentic/skills/<name>/skill.md      # project-level (wins on name conflict)
+# Legacy: ~/.spores/ and .spores/ are honoured when .agentic/ is absent
 ```
 
 Frontmatter: `name`, `description`, `tags: [a, b, c]`
@@ -104,8 +108,9 @@ Body: the skill content returned by `skill run` (pipe to an LLM).
 ### Personas on disk
 
 ```
-~/.spores/personas/<name>.md         # global (user-level)
-.spores/personas/<name>.md           # project-level (wins on name conflict)
+~/.agentic/personas/<name>.md        # global (user-level)
+.agentic/personas/<name>.md          # project-level (wins on name conflict)
+# Legacy: ~/.spores/ and .spores/ are honoured when .agentic/ is absent
 ```
 
 Flat-file layout (unlike skills which use a directory per skill). Frontmatter: `name`, `description`, `memory_tags: [...]`, `skills: [...]`, optional `task_filter: { tags: [...], status: ready }` (nested, one level deep), optional `workflow: <graph-id>`. Body is markdown with `{{cwd}}`, `{{timestamp}}`, `{{hostname}}`, `{{git_branch}}` tokens that get substituted at `persona activate` time.
@@ -114,11 +119,11 @@ Flat-file layout (unlike skills which use a directory per skill). Frontmatter: `
 
 **One hat at a time.** Personas don't compose, stack, or inherit. To pivot, deactivate one and activate another. Runtime integration for applying persona bindings (using `memory_tags` as a recall filter, etc.) is **the caller's responsibility** — spores ships the metadata, the caller wires it. Descoped from v0.1 intentionally; expected to land after we have more signal from actual use.
 
-### Config resolution (three-tier)
+### Config resolution (four-tier)
 
 1. Hardcoded defaults in `config.ts`
-2. `~/.spores/config.toml` — user-level overrides
-3. `.spores/config.toml` — project-level overrides (wins)
+2. `~/.agentic/config.toml` — global user overrides (preferred); falls back to `~/.spores/config.toml`
+3. `.agentic/config.toml` — project overrides, wins over global (preferred); falls back to `.spores/config.toml`
 
 ### Workflow runtime
 
@@ -135,9 +140,11 @@ Runtimes own send/handle/cancel verbs, the actual transport, scheduling, and han
 
 See `PROJECTS/spores/DESIGN-runtime-description.md` for the full design conversation.
 
-### SporesUri
+### URI schemes
 
-`spores://` is a reserved URI scheme for SPORES-owned compute. Branded type `SporesUri = \`spores://\${string}\`` in `types.ts`. Referenced from skill bodies, dispatched by the host runtime (e.g. Beacon).
+`agentic://` is the preferred URI scheme for Agentic-owned compute. Branded type `AgenticUri = \`agentic://\${string}\`` in `types.ts`. Referenced from skill bodies, dispatched by the host runtime.
+
+`spores://` is the legacy scheme; `SporesUri` is preserved but deprecated. Use `AgenticUri` in new code.
 
 ## Conventions
 
@@ -152,15 +159,16 @@ See `PROJECTS/spores/DESIGN-runtime-description.md` for the full design conversa
 
 Artifacts are versioned markdown blobs — the agent's durable output store for a project.
 
-**On-disk layout** (inside `.spores/artifacts/`):
+**On-disk layout** (inside `.agentic/artifacts/`):
 
 ```
-.spores/artifacts/<ulid>/meta.json    — ArtifactRecord (type, title, version, locked, tags, …)
-.spores/artifacts/<ulid>/v1.md        — body at version 1
-.spores/artifacts/<ulid>/v2.md        — body at version 2 (iterate write)
+.agentic/artifacts/<ulid>/meta.json    — ArtifactRecord (type, title, version, locked, tags, …)
+.agentic/artifacts/<ulid>/v1.md        — body at version 1
+.agentic/artifacts/<ulid>/v2.md        — body at version 2 (iterate write)
 ```
 
-`body_ref` in `meta.json` is relative to `.spores/artifacts/` — e.g. `"<id>/v2.md"`.
+`body_ref` in `meta.json` is relative to `.agentic/artifacts/` — e.g. `"<id>/v2.md"`.
+Legacy: `.spores/artifacts/` is used when `.agentic/artifacts/` does not exist.
 
 **Write modes:**
 
@@ -176,25 +184,25 @@ Artifacts are versioned markdown blobs — the agent's durable output store for 
 
 ```bash
 # Create
-spores artifact create brief "## Q2 Launch\n\nTBD." --title "Q2 Brief" --tags "q2,launch"
+agentic artifact create brief "## Q2 Launch\n\nTBD." --title "Q2 Brief" --tags "q2,launch"
 
 # Read (pipe-friendly — raw body to stdout in human mode, JSON with --json)
-spores artifact read 01JXYZ... | pbcopy
+agentic artifact read 01JXYZ... | pbcopy
 
 # Iterate
-spores artifact write 01JXYZ... "## Q2 Launch\n\nUpdated content." --mode iterate
+agentic artifact write 01JXYZ... "## Q2 Launch\n\nUpdated content." --mode iterate
 
 # Targeted edit
-spores artifact edit 01JXYZ... --old "TBD." --new "Final copy."
+agentic artifact edit 01JXYZ... --old "TBD." --new "Final copy."
 
 # Inspect metadata
-spores artifact inspect 01JXYZ... --json
+agentic artifact inspect 01JXYZ... --json
 
 # List with filter
-spores artifact list --type brief --json
+agentic artifact list --type brief --json
 
 # Lock the final version
-spores artifact lock 01JXYZ...
+agentic artifact lock 01JXYZ...
 ```
 
 **Hook events:**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ This repo dogfoods its own toolbelt. Before touching code, run the three-command
 A TypeScript library + CLI for agent in-loop primitives:
 
 1. **Memory** — remember/recall/dream with L1/L2/L3 tiers
-2. **Skills** — load and run skill.md files from `.spores/skills/`
+2. **Skills** — load and run skill.md files from `.agentic/skills/`
 3. **Workflow** — digraph runtime (GraphDef → Run → Transitions, state derived from history)
 4. **Tasks** — typed adapter interface (ULID IDs, Taskwarrior-shaped)
 5. **Persona** — activate a hat at the start of a turn: metadata (memory_tags, skills, task_filter, workflow, routing hints) + a rendered body with live situational facts. Declarative attention, not enforced scope.
@@ -213,9 +213,9 @@ agentic artifact lock 01JXYZ...
 | `artifact.written` | `artifact write`, `artifact edit` |
 | `artifact.locked` | `artifact lock` |
 
-Hook env vars: `SPORES_ARTIFACT_ID`, `SPORES_ARTIFACT_TYPE`, `SPORES_ARTIFACT_TITLE`, `SPORES_ARTIFACT_TAGS` (create); `SPORES_ARTIFACT_ID`, `SPORES_ARTIFACT_VERSION`, `SPORES_ARTIFACT_MODE` (written); `SPORES_ARTIFACT_ID`, `SPORES_ARTIFACT_FINAL_VERSION` (locked).
+Hook env vars: `AGENTIC_ARTIFACT_ID`, `AGENTIC_ARTIFACT_TYPE`, `AGENTIC_ARTIFACT_TITLE`, `AGENTIC_ARTIFACT_TAGS` (create); `AGENTIC_ARTIFACT_ID`, `AGENTIC_ARTIFACT_VERSION`, `AGENTIC_ARTIFACT_MODE` (written); `AGENTIC_ARTIFACT_ID`, `AGENTIC_ARTIFACT_FINAL_VERSION` (locked). Legacy `SPORES_*` mirrors are set alongside for compatibility.
 
-**Dogfood hook:** `.spores/hooks/artifact.written` — indexes the artifact reference into memory after every write so it's searchable via `spores memory recall`.
+**Dogfood hook:** `.agentic/hooks/artifact.written` — indexes the artifact reference into memory after every write so it's searchable via `agentic memory recall`.
 
 **Workflow → artifact worked example:**
 
@@ -234,12 +234,12 @@ After the workflow run completes and the node produces its output, the caller pe
 
 ```bash
 # Node output lands in the transition; caller writes it as a named artifact
-BODY=$(spores workflow status "$RUN_ID" --json | jq -r '.nodes[-1].artifact.content')
-ARTIFACT_ID=$(spores artifact create brief "$BODY" --title "Q2 Brief" --tags "briefing,q2" --json | jq -r '.artifact.id')
+BODY=$(agentic workflow status "$RUN_ID" --json | jq -r '.nodes[-1].artifact.content')
+ARTIFACT_ID=$(agentic artifact create brief "$BODY" --title "Q2 Brief" --tags "briefing,q2" --json | jq -r '.artifact.id')
 
 # artifact.written hook fires automatically → reference indexed into memory
 # Later retrieval
-spores memory recall "Q2 Brief"
+agentic memory recall "Q2 Brief"
 ```
 
 The dogfood hook wires the last step without any special-cased plumbing in spores itself.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to `@tnezdev/spores`. Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follows [semver](https://semver.org/).
 
+## Unreleased — Rename to Agentic (migration window)
+
+The package is migrating from `spores` → `agentic`. This section tracks the compatibility changes landing before the final rename release. All changes are backward-compatible — existing `.spores/`, `spores` CLI, `SporesConfig`, and `SPORES_*` env vars continue to work throughout the migration window.
+
+### Added
+
+- **`agentic` CLI alias.** `agentic <command>` is now the preferred entry point; `spores <command>` remains as a compatibility alias. Both dispatch through identical code.
+- **`AgenticConfig` type** — preferred alias for `SporesConfig`. `SporesConfig` is still exported and valid. (#63)
+- **`AgenticUri` type** — `agentic://${string}` scheme for Agentic-owned compute URIs. `SporesUri` (`spores://`) is preserved but marked deprecated. (#63)
+- **`.agentic/` config directory precedence.** All filesystem adapters (memory, workflow, tasks, artifact, personas, skills, hooks) now resolve `.agentic/<subdir>` before `.spores/<subdir>`. If `.agentic/` is absent but `.spores/` is present, `.spores/` is used automatically — no migration required. (#60)
+- **`src/resolve-dir.ts`.** `resolveProjectDir(baseDir, ...segments)` and `resolveGlobalDir(...segments)` — shared helpers for the `.agentic/` → `.spores/` fallback logic.
+- **`AGENTIC_*` hook environment variables.** `AGENTIC_EVENT` and `AGENTIC_BIN` are injected alongside `SPORES_EVENT` and `SPORES_BIN`. Every caller-provided `SPORES_*` key receives an `AGENTIC_*` mirror automatically, and vice versa — existing hook scripts work without edits. (#64)
+- **`AGENTIC_HOOKS_DIR` override** — accepted alongside `SPORES_HOOKS_DIR`. (#64)
+- **`.agentic/` dogfood directory** — the repo now dogfoods `.agentic/` as its primary project directory; `.spores/` is preserved during the compatibility window. (#65)
+
+### Migration notes
+
+| Old | New (preferred) |
+|-----|----------------|
+| `spores <cmd>` | `agentic <cmd>` |
+| `.spores/config.toml` | `.agentic/config.toml` |
+| `SporesConfig` | `AgenticConfig` |
+| `SporesUri` / `spores://` | `AgenticUri` / `agentic://` |
+| `SPORES_EVENT`, `SPORES_BIN` | `AGENTIC_EVENT`, `AGENTIC_BIN` (both injected) |
+| `~/.spores/` | `~/.agentic/` |
+
+Run `agentic init` in any new project to scaffold `.agentic/` directly.
+
 ## 0.4.1 — 2026-04-27
 
 The Workers/Node release. Lifts the Bun-only constraint and ships three new `Source` implementations covering the storage backends Cloudflare Workers consumers need.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# @tnezdev/spores
+# @tnezdev/spores → becoming `@tnezdev/agentic`
+
+> **Rename in progress.** The package is migrating from `spores` to `agentic`. During the compatibility window both names work. New code should use `agentic`, `.agentic/`, and `AGENTIC_*`.
 
 Executable toolbelt for agent self-improvement. Five in-loop primitives — memory, skills, workflow, tasks, and persona — with zero production dependencies, built for Bun.
 
@@ -12,23 +14,24 @@ npm install @tnezdev/spores
 ## Quick start
 
 ```bash
-# Scaffold .spores/ directory in your project
-spores init
+# Scaffold .agentic/ directory in your project
+agentic init          # preferred
+spores init           # compatibility alias
 
 # Store a memory
-spores memory remember "always emit types from the public API" --tags style,api
+agentic memory remember "always emit types from the public API" --tags style,api
 
 # Load a skill
-spores skill list
-spores skill run release-check | llm
+agentic skill list
+agentic skill run release-check | llm
 
 # Track a task
-spores task add "update CHANGELOG before tagging"
-spores task next
+agentic task add "update CHANGELOG before tagging"
+agentic task next
 
 # Activate a persona (pipe into your LLM as system prompt)
-spores persona list
-spores persona activate spores-maintainer | llm --system -
+agentic persona list
+agentic persona activate spores-maintainer | llm --system -
 ```
 
 ## Primitives
@@ -41,7 +44,7 @@ spores persona activate spores-maintainer | llm --system -
 | **Tasks** | ULID-keyed task queue with status transitions and annotations |
 | **Persona** | Activate a "hat" at the start of a turn: memory tags, skills, task filter, workflow, and a rendered body with live situational facts |
 
-All five primitives read from `.spores/` in your project root, with optional global overrides from `~/.spores/`.
+All five primitives read from `.agentic/` in your project root, with optional global overrides from `~/.agentic/`. Legacy `.spores/` and `~/.spores/` paths are honoured during the compatibility window when `.agentic/` is absent.
 
 ## Flags
 
@@ -53,7 +56,7 @@ All five primitives read from `.spores/` in your project root, with optional glo
 
 ## Working example
 
-The `.spores/` directory in this repo is the v0.1 dogfood — a persona, a skill, a workflow, tasks, and memories that are used to build spores itself. Read [`.spores/README.md`](.spores/README.md) for a tour.
+The `.agentic/` directory in this repo is the dogfood — a persona, a skill, a workflow, tasks, and memories that are used to build this package itself. Read [`.agentic/ONRAMP.md`](.agentic/ONRAMP.md) for a tour.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

Completes the visible surface of the Rename to Agentic milestone.

- Closes #65: `.agentic/` is now the primary dogfood directory; `.spores/` preserved during compatibility window
- Closes #66: README, AGENTS.md, and CHANGELOG updated to prefer Agentic naming; legacy paths documented

## Changes

**Dogfood migration (#65)**
- `.agentic/` seeded with all tracked content from `.spores/` (config, hooks, memory, personas, skills, tasks, workflows)
- `.agentic/config.toml` updated to use `.agentic/` paths
- `.agentic/ONRAMP.md` updated for `agentic` CLI and `.agentic/` paths; legacy compatibility note added
- `.gitignore`: add `.agentic/runs/` as ephemeral run state

**Docs (#66)**
- `README.md`: headline rename-in-progress; prefer `agentic` in quick-start; update primitive path descriptions
- `AGENTS.md`: update to Agentic naming throughout; add rename banner; update CLI/path examples; `AgenticUri` section
- `CHANGELOG.md`: new "Unreleased — Rename to Agentic" section covering #60/#61/#63/#64/#65/#66 with migration table

## Test plan

- [ ] `bun test` — should pass (no code changes, dogfood/docs only)
- [ ] `bun run typecheck` — clean
- [ ] `agentic persona activate spores-maintainer` loads from `.agentic/personas/`
- [ ] `agentic task next` reads from `.agentic/tasks/`
- [ ] Existing `.spores/` project still works (fallback from #79 / PR 2)