### PR TITLE
docs(capability): add neutral declaration fixtures and host guidance

### DIFF
--- a/docs/capability-contracts.md
+++ b/docs/capability-contracts.md
@@ -201,6 +201,113 @@ The host runtime owns:
 
 The portable package should not assume a particular host architecture.
 
+## How a Host Consumes Declarations
+
+The portable layer provides helpers that let a host make enforcement decisions from a loaded declaration. No host logic needs to parse effects strings or duplicate dispatch-matching rules.
+
+### 1. Validate on load
+
+After reading a declaration from any source (file, API, registry), pass it through
+`validateCapability` before using it:
+
+```typescript
+import { validateCapability } from "@tnezdev/spores"
+
+const result = validateCapability(raw)
+if (!result.valid) {
+  // result.errors is a non-empty array of { field, message } objects.
+  // Return a structured error to the caller — do not proceed.
+  return { error: "capability_misconfigured", details: result.errors }
+}
+```
+
+Validation confirms that required fields are present, all effect names are known, approval
+configuration is internally consistent, and connection entries are structurally sound. It does not
+make network calls, resolve credentials, or check whether a provider is reachable.
+
+### 2. Gate on dispatch context
+
+Before running any capability, check whether the inbound context is permitted:
+
+```typescript
+import { capabilityMatchesDispatch } from "@tnezdev/spores"
+
+if (!capabilityMatchesDispatch(def, inboundDispatch)) {
+  return { error: "dispatch_not_allowed" }
+}
+```
+
+`capabilityMatchesDispatch` returns `true` when `policy.dispatch` is absent (no constraint) and
+applies inclusion checks when the field is present. The host provides the dispatch value from its
+own session or request context.
+
+### 3. Check required connections
+
+If `def.requires.connections` is non-empty, the host must ensure each connection is available
+before continuing:
+
+```typescript
+for (const conn of def.requires.connections ?? []) {
+  const resolved = await host.resolveConnection(conn.provider, conn.capabilities)
+  if (!resolved) {
+    return { error: "missing_connection", provider: conn.provider }
+  }
+}
+```
+
+The declaration names the provider and required capability scopes. The host owns credential
+storage, token refresh, account selection, and secret handling. These details never appear in the
+portable declaration.
+
+### 4. Gate individual tool calls on declared effects
+
+Before allowing a tool execution, verify the capability declares the corresponding effect:
+
+```typescript
+import { capabilityAllowsEffect, capabilityAllowsTool } from "@tnezdev/spores"
+
+if (!capabilityAllowsTool(def, toolName)) {
+  return { error: "tool_not_allowed" }
+}
+if (!capabilityAllowsEffect(def, requiredEffect)) {
+  return { error: "effect_not_allowed" }
+}
+```
+
+### 5. Require approval before sensitive effects
+
+Check whether human approval is required before permitting an effect to execute:
+
+```typescript
+import { capabilityRequiresApprovalFor } from "@tnezdev/spores"
+
+if (capabilityRequiresApprovalFor(def, "external.write")) {
+  const approved = await host.requestApproval(def, turn)
+  if (!approved) {
+    return { error: "approval_rejected" }
+  }
+}
+```
+
+`mode: "before_effect"` means the host must gate execution on approval. `mode: "after_effect"`
+means approval is a post-execution confirmation. The declaration names the requirement; the host
+owns the approval store, notification surface, approve/reject flow, idempotency, and continuation
+behavior.
+
+### What the portable layer does not provide
+
+The portable declaration layer defines vocabulary and structural helpers. It does not provide:
+
+- A credential store or token manager
+- An approval UI, inbox, or notification surface
+- A provider client or API adapter
+- An artifact storage backend
+- Session management or turn state
+- Deployment or materialization logic
+
+A host that needs any of those things builds or selects its own implementation and drives it using
+the declaration fields as input.
+
 ## Non-Goals
 
 This design does not introduce a hosted runtime. It does not define provider APIs, credential storage, approval UI, artifact storage, deployment infrastructure, or session management.
@@ -209,12 +316,107 @@ Those are host bindings. The portable layer defines the shared vocabulary that l
 
 ## Neutral Example Set
 
-The following examples are useful fixtures for validating the vocabulary without binding it to a specific host:
+The following examples are useful fixtures for validating the vocabulary without binding it to a specific host. Each is stored as a JSON file under `src/capability/fixtures/` and validated in tests using `validateCapability`.
 
-- `issue_tracker.list_issues`: external read through a required issue-tracker connection
-- `issue_tracker.create_issue`: external write with approval before effect
-- `communication.place_call`: user notification / external write constrained by dispatch context
-- `web.search`: external read with no user-owned connection
-- `document.create_slide_deck`: artifact write from model-provided structured content
+### `issue_tracker.list_issues`
+
+External read through a required issue-tracker connection. No approval is needed because no write
+effect is declared.
+
+```json
+{
+  "name": "issue_tracker.list_issues",
+  "description": "Use when the user asks to list issues from an external issue tracker.",
+  "skill": "issue-triage",
+  "requires": {
+    "connections": [
+      { "provider": "issue_tracker", "capabilities": ["issues.read"] }
+    ]
+  },
+  "policy": {
+    "effects": ["external.read"]
+  }
+}
+```
+
+### `issue_tracker.create_issue`
+
+External write with approval required before the effect executes. Dispatch is constrained to web
+and chat surfaces. The capability writes an `issue_reference` artifact.
+
+```json
+{
+  "name": "issue_tracker.create_issue",
+  "description": "Use when the user asks to create an issue in an external issue tracker.",
+  "skill": "issue-triage",
+  "requires": {
+    "connections": [
+      { "provider": "issue_tracker", "capabilities": ["issues.write"] }
+    ]
+  },
+  "policy": {
+    "dispatch": { "from": ["surface:web", "surface:chat"] },
+    "tools": ["integration.invoke", "approval.request"],
+    "effects": ["external.write", "approval.request"],
+    "approval": { "required_for": ["external.write"], "mode": "before_effect" }
+  },
+  "artifacts": {
+    "writes": ["issue_reference"]
+  }
+}
+```
+
+### `communication.place_call`
+
+External write and user notification constrained to chat and voice surfaces. Approval is required
+before the call is placed. No connection requirement is declared because call routing is a host
+concern.
+
+```json
+{
+  "name": "communication.place_call",
+  "description": "Use when the user asks to place an outbound call to another person.",
+  "policy": {
+    "dispatch": { "from": ["surface:chat", "surface:voice"] },
+    "effects": ["external.write", "user.notify", "approval.request"],
+    "approval": { "required_for": ["external.write"], "mode": "before_effect" }
+  }
+}
+```
+
+### `web.search`
+
+External read with no user-owned connection. No approval is needed. This is the minimal
+declaration shape — only `name`, `description`, and a single declared effect.
+
+```json
+{
+  "name": "web.search",
+  "description": "Use when the user asks to search the web for current information.",
+  "policy": {
+    "effects": ["external.read"]
+  }
+}
+```
+
+### `document.create_slide_deck`
+
+Artifact write from model-provided structured content. No external connection or approval is
+required. The capability declares the kind of artifact it produces.
+
+```json
+{
+  "name": "document.create_slide_deck",
+  "description": "Use when the user asks to create a slide deck from structured content.",
+  "policy": {
+    "effects": ["artifact.write"]
+  },
+  "artifacts": {
+    "writes": ["slide_deck"]
+  }
+}
+```
+
+---
 
 If these examples cannot be represented cleanly, the declaration vocabulary is probably missing a concept.

--- a/src/capability/fixtures.test.ts
+++ b/src/capability/fixtures.test.ts
@@ -1,11 +1,18 @@
 /**
- * Type-level fixtures for the capability declaration vocabulary (issue #69).
+ * Fixtures for the capability declaration vocabulary.
  *
- * These are not runtime tests — there is no executable logic to test in a
- * pure-type issue. Instead, each fixture is a valid `CapabilityDef` literal
- * that the TypeScript compiler checks at compile time. If a fixture fails to
- * typecheck, the declaration vocabulary is missing a concept or is too
- * narrow.
+ * Two layers of coverage:
+ *
+ * 1. Type-level assignment checks (issue #69) — compile-time only. Each
+ *    fixture is a valid `CapabilityDef` literal checked by the TypeScript
+ *    compiler. If a fixture fails to typecheck, the declaration vocabulary is
+ *    missing a concept or is too narrow.
+ *
+ * 2. Runtime fixture validation (issue #74) — each neutral example is stored
+ *    as a JSON file under src/capability/fixtures/ and loaded at test time as
+ *    `unknown`. Passing the result through `validateCapability()` proves that
+ *    the validator accepts the canonical declaration shapes and that the JSON
+ *    files have not drifted from the type vocabulary.
  *
  * Neutral examples from docs/capability-contracts.md:
  *   - issue_tracker.list_issues
@@ -15,9 +22,12 @@
  *   - document.create_slide_deck
  */
 
-import { describe, it } from "bun:test"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, it } from "bun:test"
 import type { CapabilityDef } from "../types.js"
 import { CAPABILITY_EFFECTS, POLICY_ERRORS } from "../types.js"
+import { validateCapability } from "./helpers.js"
 
 // ---------------------------------------------------------------------------
 // Type-level assignment check — each fixture must satisfy CapabilityDef
@@ -159,6 +169,61 @@ describe("POLICY_ERRORS", () => {
       if (!POLICY_ERRORS.includes(name)) {
         throw new Error(`Missing policy error: ${name}`)
       }
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Runtime fixture validation — neutral JSON examples (issue #74)
+//
+// Each fixture file under src/capability/fixtures/ is loaded as unknown text
+// and validated through validateCapability(). This proves:
+//   (a) the JSON files are well-formed and match the declaration vocabulary
+//   (b) validateCapability() accepts all canonical neutral examples
+//   (c) the files have not drifted as the vocabulary evolves
+// ---------------------------------------------------------------------------
+
+const FIXTURES_DIR = join(import.meta.dir, "fixtures")
+
+function loadFixtureJson(filename: string): unknown {
+  const text = readFileSync(join(FIXTURES_DIR, filename), "utf-8")
+  return JSON.parse(text)
+}
+
+const NEUTRAL_FIXTURES = [
+  "issue_tracker.list_issues.json",
+  "issue_tracker.create_issue.json",
+  "communication.place_call.json",
+  "web.search.json",
+  "document.create_slide_deck.json",
+] as const
+
+describe("neutral fixture files", () => {
+  for (const filename of NEUTRAL_FIXTURES) {
+    const capabilityName = filename.replace(/\.json$/, "")
+    it(`${capabilityName} passes validateCapability`, () => {
+      const raw = loadFixtureJson(filename)
+      const result = validateCapability(raw)
+      if (!result.valid) {
+        throw new Error(
+          `Fixture ${filename} failed validation:\n${JSON.stringify(result.errors, null, 2)}`,
+        )
+      }
+    })
+  }
+
+  it("all five neutral examples are present in the fixtures directory", () => {
+    const expected = [
+      "issue_tracker.list_issues.json",
+      "issue_tracker.create_issue.json",
+      "communication.place_call.json",
+      "web.search.json",
+      "document.create_slide_deck.json",
+    ]
+    for (const filename of expected) {
+      // loadFixtureJson throws if the file is missing — that surfaces a clear
+      // failure message rather than a confusing undefined
+      expect(() => loadFixtureJson(filename)).not.toThrow()
     }
   })
 })

--- a/src/capability/fixtures/communication.place_call.json
+++ b/src/capability/fixtures/communication.place_call.json
@@ -1,0 +1,14 @@
+{
+  "name": "communication.place_call",
+  "description": "Use when the user asks to place an outbound call to another person.",
+  "policy": {
+    "dispatch": {
+      "from": ["surface:chat", "surface:voice"]
+    },
+    "effects": ["external.write", "user.notify", "approval.request"],
+    "approval": {
+      "required_for": ["external.write"],
+      "mode": "before_effect"
+    }
+  }
+}

--- a/src/capability/fixtures/document.create_slide_deck.json
+++ b/src/capability/fixtures/document.create_slide_deck.json
@@ -1,0 +1,10 @@
+{
+  "name": "document.create_slide_deck",
+  "description": "Use when the user asks to create a slide deck from structured content.",
+  "policy": {
+    "effects": ["artifact.write"]
+  },
+  "artifacts": {
+    "writes": ["slide_deck"]
+  }
+}

--- a/src/capability/fixtures/issue_tracker.create_issue.json
+++ b/src/capability/fixtures/issue_tracker.create_issue.json
@@ -1,0 +1,27 @@
+{
+  "name": "issue_tracker.create_issue",
+  "description": "Use when the user asks to create an issue in an external issue tracker.",
+  "skill": "issue-triage",
+  "requires": {
+    "connections": [
+      {
+        "provider": "issue_tracker",
+        "capabilities": ["issues.write"]
+      }
+    ]
+  },
+  "policy": {
+    "dispatch": {
+      "from": ["surface:web", "surface:chat"]
+    },
+    "tools": ["integration.invoke", "approval.request"],
+    "effects": ["external.write", "approval.request"],
+    "approval": {
+      "required_for": ["external.write"],
+      "mode": "before_effect"
+    }
+  },
+  "artifacts": {
+    "writes": ["issue_reference"]
+  }
+}

--- a/src/capability/fixtures/issue_tracker.list_issues.json
+++ b/src/capability/fixtures/issue_tracker.list_issues.json
@@ -1,0 +1,16 @@
+{
+  "name": "issue_tracker.list_issues",
+  "description": "Use when the user asks to list issues from an external issue tracker.",
+  "skill": "issue-triage",
+  "requires": {
+    "connections": [
+      {
+        "provider": "issue_tracker",
+        "capabilities": ["issues.read"]
+      }
+    ]
+  },
+  "policy": {
+    "effects": ["external.read"]
+  }
+}

--- a/src/capability/fixtures/web.search.json
+++ b/src/capability/fixtures/web.search.json
@@ -1,0 +1,7 @@
+{
+  "name": "web.search",
+  "description": "Use when the user asks to search the web for current information.",
+  "policy": {
+    "effects": ["external.read"]
+  }
+}


### PR DESCRIPTION
Closes #74.

## Summary

- **5 JSON fixture files** added under `src/capability/fixtures/` — one per neutral example from `docs/capability-contracts.md`: `issue_tracker.list_issues`, `issue_tracker.create_issue`, `communication.place_call`, `web.search`, and `document.create_slide_deck`. All use product-neutral provider names; no private or product-specific details.
- **Runtime validation test suite** added to `src/capability/fixtures.test.ts` (issue #74 layer on top of the existing issue #69 type-level layer). Each JSON file is loaded as `unknown` via `readFileSync` / `JSON.parse` and passed through `validateCapability()`. The suite also asserts all five fixture files are present. If a fixture drifts from the vocabulary, the test surfaces a field-level error message.
- **Host guidance** added to `docs/capability-contracts.md` — new section "How a Host Consumes Declarations" with annotated code examples for each step: validate on load, gate on dispatch, resolve connections, check per-tool effect allowances, and gate on approval policy. The Neutral Example Set section is expanded from a one-line summary list to full annotated JSON listings of all five examples.

## Test plan

- [ ] `bun test` — 535/535 pass
- [ ] `bun run typecheck` — clean
- [ ] Review `src/capability/fixtures/` for product-neutral names
- [ ] Review `docs/capability-contracts.md` host guidance section for accuracy