### PR TITLE
feat(skill): allow skills to reference capabilities

### DIFF
--- a/docs/capability-contracts.md
+++ b/docs/capability-contracts.md
@@ -34,6 +34,34 @@ Example:
 
 The skill body can explain when to use the procedure, what information to gather, and how to phrase outputs. It should not be the only source of truth for executable permissions.
 
+## Skill Capability References
+
+A skill file may declare which capabilities it is associated with using the `capabilities` frontmatter field. This is metadata only — `skill run` still outputs model-readable skill content and does not enforce capability policy or execute capability behavior.
+
+A single capability name:
+
+```text
+---
+name: issue-triage
+description: Triage and route inbound issues.
+capabilities: issue_tracker.list_issues
+---
+```
+
+Multiple capability names use array syntax:
+
+```text
+---
+name: issue-triage
+description: Triage and route inbound issues.
+capabilities: [issue_tracker.list_issues, issue_tracker.create_issue]
+---
+```
+
+Capability names use dot-separated namespacing by convention: `<domain>.<verb>`, e.g. `issue_tracker.create_issue`.
+
+Hosts may use the `capabilities` list on `SkillRef` and `Skill` to bind model-readable skill instructions to the matching executable policy contracts. Skill files without a `capabilities` field load unchanged; the field is absent (`undefined`) rather than an empty array.
+
 ## Capabilities
 
 A capability is the host-facing execution contract around a skill or procedure.

--- a/src/skills/filesystem.test.ts
+++ b/src/skills/filesystem.test.ts
@@ -221,4 +221,67 @@ Body.
       expect(refs.map((r) => r.name)).toEqual(["ok"])
     })
   })
+
+  describe("capability references", () => {
+    it("parses a single capability reference as a one-element array", async () => {
+      const source = new InMemorySource({
+        triage: `---\nname: triage\ndescription: Triage issues\ncapabilities: issue_tracker.list_issues\n---\nBody.\n`,
+      })
+      const skill = await loadSkillFromSource("triage", source)
+      expect(skill).not.toBeUndefined()
+      expect(skill!.capabilities).toEqual(["issue_tracker.list_issues"])
+    })
+
+    it("parses multiple capability references from array syntax", async () => {
+      const source = new InMemorySource({
+        call: `---\nname: call\ndescription: Place a call\ncapabilities: [communication.place_call, user.notify]\n---\nBody.\n`,
+      })
+      const skill = await loadSkillFromSource("call", source)
+      expect(skill).not.toBeUndefined()
+      expect(skill!.capabilities).toEqual(["communication.place_call", "user.notify"])
+    })
+
+    it("does not set capabilities when the frontmatter field is absent", async () => {
+      const source = new InMemorySource({
+        plain: `---\nname: plain\ndescription: No caps\n---\nBody.\n`,
+      })
+      const skill = await loadSkillFromSource("plain", source)
+      expect(skill).not.toBeUndefined()
+      expect(skill!.capabilities).toBeUndefined()
+    })
+
+    it("exposes capabilities on SkillRef from listSkillsFromSource", async () => {
+      const source = new InMemorySource({
+        search: `---\nname: search\ndescription: Web search\ncapabilities: [web.search]\n---\n`,
+      })
+      const refs = await listSkillsFromSource(source)
+      expect(refs).toHaveLength(1)
+      expect(refs[0]!.capabilities).toEqual(["web.search"])
+    })
+
+    it("backward compat: existing skills without capabilities load unchanged", async () => {
+      const source = new InMemorySource({
+        old: `---\nname: old\ndescription: Old skill\ntags: [legacy]\n---\nOld body.\n`,
+      })
+      const skill = await loadSkillFromSource("old", source)
+      expect(skill).not.toBeUndefined()
+      expect(skill!.name).toBe("old")
+      expect(skill!.tags).toEqual(["legacy"])
+      expect(skill!.capabilities).toBeUndefined()
+    })
+
+    it("filesystem: capabilities round-trip through writeSkill and loadSkill", async () => {
+      await writeSkill(
+        tmpDir,
+        "cap-skill",
+        `---\nname: cap-skill\ndescription: Has caps\ncapabilities: [issue_tracker.create_issue, communication.place_call]\n---\nBody.\n`,
+      )
+      const skill = await loadSkill("cap-skill", tmpDir)
+      expect(skill).not.toBeUndefined()
+      expect(skill!.capabilities).toEqual([
+        "issue_tracker.create_issue",
+        "communication.place_call",
+      ])
+    })
+  })
 })

--- a/src/skills/filesystem.ts
+++ b/src/skills/filesystem.ts
@@ -14,6 +14,7 @@ type Frontmatter = {
   name?: string | undefined
   description?: string | undefined
   tags?: string[] | undefined
+  capabilities?: string[] | undefined
 }
 
 function parseFrontmatter(text: string): { meta: Frontmatter; body: string } {
@@ -50,11 +51,14 @@ function parseFrontmatter(text: string): { meta: Frontmatter; body: string } {
 
       if (key === "tags") {
         meta.tags = items
+      } else if (key === "capabilities") {
+        meta.capabilities = items
       }
     } else {
       const value = rest.replace(/^["']|["']$/g, "")
       if (key === "name") meta.name = value
       if (key === "description") meta.description = value
+      if (key === "capabilities") meta.capabilities = [value]
     }
   }
 
@@ -67,6 +71,9 @@ function metaToRef(meta: Frontmatter, locator: string): SkillRef | undefined {
     name: meta.name,
     description: meta.description,
     tags: meta.tags ?? [],
+    ...(meta.capabilities !== undefined
+      ? { capabilities: meta.capabilities }
+      : {}),
     path: locator,
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -170,6 +170,15 @@ export type SkillRef = {
   name: string
   description: string
   tags: string[]
+  /**
+   * Optional list of capability names this skill is associated with.
+   * A capability name uses dot-separated namespacing by convention:
+   * `<domain>.<verb>`, e.g. `"issue_tracker.create_issue"`.
+   * Hosts may use this list to bind model-readable skill instructions
+   * to executable capability policy contracts.
+   * Absent when the skill file does not declare a `capabilities` field.
+   */
+  capabilities?: string[] | undefined
   path: string // absolute path to skill.md
 }
 


### PR DESCRIPTION
Closes #73.

## Summary

- `SkillRef` (and `Skill`) gain an optional `capabilities?: string[] | undefined` field
- Skill frontmatter now accepts a `capabilities:` key — single-string or `[a, b, c]` array syntax both work
- Absent field leaves `capabilities` as `undefined` (no empty-array default) — existing skill files load unchanged
- `docs/capability-contracts.md` gains a "Skill Capability References" section with frontmatter examples and host guidance

## Scope guard

Metadata-only change. `skill run` output and execution behavior are unchanged; no capability policy is enforced by this PR.

## Test plan

- [ ] 6 new tests in `src/skills/filesystem.test.ts`: single cap, multiple caps, absent field (backward compat), `SkillRef` list path, backward compat on existing-style skills, filesystem round-trip
- [ ] 535/535 tests pass
- [ ] `tsc --noEmit` clean