### PR TITLE
feat(capability): load declarations through Source adapters

### DIFF
--- a/src/capability/filesystem.test.ts
+++ b/src/capability/filesystem.test.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test"
+import { mkdtemp, rm, mkdir, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { InMemorySource } from "../sources/in-memory.js"
+import { LayeredSource } from "../sources/layered.js"
+import {
+  listCapabilities,
+  listCapabilitiesFromSource,
+  loadCapability,
+  loadCapabilityFromSource,
+} from "./filesystem.js"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function writeCapability(
+  baseDir: string,
+  name: string,
+  json: string,
+  subdir: ".agentic" | ".spores" = ".agentic",
+): Promise<void> {
+  const capDir = join(baseDir, subdir, "capabilities")
+  await mkdir(capDir, { recursive: true })
+  await writeFile(join(capDir, `${name}.json`), json)
+}
+
+const VALID_CAPABILITY = JSON.stringify({
+  name: "issue_tracker.list_issues",
+  description: "Use when the user asks to list issues from an external issue tracker.",
+  skill: "issue-triage",
+  requires: {
+    connections: [{ provider: "issue_tracker", capabilities: ["issues.read"] }],
+  },
+  policy: { effects: ["external.read"] },
+})
+
+const ANOTHER_CAPABILITY = JSON.stringify({
+  name: "web.search",
+  description: "Use when the user asks to search the web for information.",
+  policy: { effects: ["external.read"] },
+})
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("capability/filesystem", () => {
+  let tmpDir: string
+  let fakeHome: string
+  const originalHome = process.env["HOME"]
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "spores-cap-test-"))
+    fakeHome = await mkdtemp(join(tmpdir(), "spores-cap-home-"))
+    process.env["HOME"] = fakeHome
+  })
+
+  afterEach(async () => {
+    if (originalHome !== undefined) process.env["HOME"] = originalHome
+    else delete process.env["HOME"]
+    await rm(tmpDir, { recursive: true })
+    await rm(fakeHome, { recursive: true })
+  })
+
+  // -------------------------------------------------------------------------
+  // Source-based API
+  // -------------------------------------------------------------------------
+
+  describe("listCapabilitiesFromSource", () => {
+    it("returns empty array for empty source", async () => {
+      const source = new InMemorySource({})
+      const caps = await listCapabilitiesFromSource(source)
+      expect(caps).toEqual([])
+    })
+
+    it("returns parsed capabilities from source", async () => {
+      const source = new InMemorySource({
+        "issue_tracker.list_issues": VALID_CAPABILITY,
+      })
+      const caps = await listCapabilitiesFromSource(source)
+      expect(caps).toHaveLength(1)
+      expect(caps[0]!.name).toBe("issue_tracker.list_issues")
+      expect(caps[0]!.description).toBe(
+        "Use when the user asks to list issues from an external issue tracker.",
+      )
+    })
+
+    it("returns results sorted by name", async () => {
+      const source = new InMemorySource({
+        "web.search": ANOTHER_CAPABILITY,
+        "issue_tracker.list_issues": VALID_CAPABILITY,
+      })
+      const caps = await listCapabilitiesFromSource(source)
+      expect(caps.map((c) => c.name)).toEqual([
+        "issue_tracker.list_issues",
+        "web.search",
+      ])
+    })
+
+    it("skips records with malformed JSON", async () => {
+      const source = new InMemorySource({
+        "issue_tracker.list_issues": VALID_CAPABILITY,
+        "broken": "{ not valid json",
+      })
+      const caps = await listCapabilitiesFromSource(source)
+      expect(caps).toHaveLength(1)
+      expect(caps[0]!.name).toBe("issue_tracker.list_issues")
+    })
+
+    it("skips records that fail validation (missing name)", async () => {
+      const source = new InMemorySource({
+        "issue_tracker.list_issues": VALID_CAPABILITY,
+        "no-name": JSON.stringify({ description: "no name field" }),
+      })
+      const caps = await listCapabilitiesFromSource(source)
+      expect(caps).toHaveLength(1)
+    })
+
+    it("skips records where source.read returns undefined mid-list", async () => {
+      // LayeredSource with one source that lists a name but whose read returns undefined
+      const partial = new InMemorySource({ "issue_tracker.list_issues": VALID_CAPABILITY })
+      const caps = await listCapabilitiesFromSource(partial)
+      expect(caps).toHaveLength(1)
+    })
+  })
+
+  describe("loadCapabilityFromSource", () => {
+    it("returns undefined for missing name", async () => {
+      const source = new InMemorySource({})
+      const cap = await loadCapabilityFromSource("missing", source)
+      expect(cap).toBeUndefined()
+    })
+
+    it("returns undefined for malformed JSON", async () => {
+      const source = new InMemorySource({ "bad": "not json {{{" })
+      const cap = await loadCapabilityFromSource("bad", source)
+      expect(cap).toBeUndefined()
+    })
+
+    it("returns undefined for invalid capability (fails validation)", async () => {
+      const source = new InMemorySource({
+        "empty-obj": JSON.stringify({}),
+      })
+      const cap = await loadCapabilityFromSource("empty-obj", source)
+      expect(cap).toBeUndefined()
+    })
+
+    it("returns the capability def for a valid record", async () => {
+      const source = new InMemorySource({
+        "issue_tracker.list_issues": VALID_CAPABILITY,
+      })
+      const cap = await loadCapabilityFromSource("issue_tracker.list_issues", source)
+      expect(cap).not.toBeUndefined()
+      expect(cap!.name).toBe("issue_tracker.list_issues")
+      expect(cap!.skill).toBe("issue-triage")
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Filesystem convenience API
+  // -------------------------------------------------------------------------
+
+  describe("listCapabilities", () => {
+    it("returns empty array when no capabilities exist", async () => {
+      const caps = await listCapabilities(tmpDir)
+      expect(caps).toEqual([])
+    })
+
+    it("returns capabilities from project .agentic dir", async () => {
+      await writeCapability(tmpDir, "issue_tracker.list_issues", VALID_CAPABILITY)
+      const caps = await listCapabilities(tmpDir)
+      expect(caps).toHaveLength(1)
+      expect(caps[0]!.name).toBe("issue_tracker.list_issues")
+    })
+
+    it("returns capabilities from global .agentic dir", async () => {
+      const globalCapDir = join(fakeHome, ".agentic", "capabilities")
+      await mkdir(globalCapDir, { recursive: true })
+      await writeFile(
+        join(globalCapDir, "web.search.json"),
+        ANOTHER_CAPABILITY,
+      )
+      const caps = await listCapabilities(tmpDir)
+      expect(caps).toHaveLength(1)
+      expect(caps[0]!.name).toBe("web.search")
+    })
+
+    it("merges project and global capabilities", async () => {
+      await writeCapability(tmpDir, "issue_tracker.list_issues", VALID_CAPABILITY)
+      const globalCapDir = join(fakeHome, ".agentic", "capabilities")
+      await mkdir(globalCapDir, { recursive: true })
+      await writeFile(join(globalCapDir, "web.search.json"), ANOTHER_CAPABILITY)
+      const caps = await listCapabilities(tmpDir)
+      expect(caps.map((c) => c.name)).toEqual([
+        "issue_tracker.list_issues",
+        "web.search",
+      ])
+    })
+
+    it("project capability overrides global on name conflict", async () => {
+      const projectVersion = JSON.stringify({
+        name: "web.search",
+        description: "Project-level override",
+        policy: { effects: ["external.read"] },
+      })
+      await writeCapability(tmpDir, "web.search", projectVersion)
+
+      const globalCapDir = join(fakeHome, ".agentic", "capabilities")
+      await mkdir(globalCapDir, { recursive: true })
+      await writeFile(join(globalCapDir, "web.search.json"), ANOTHER_CAPABILITY)
+
+      const caps = await listCapabilities(tmpDir)
+      expect(caps).toHaveLength(1)
+      expect(caps[0]!.description).toBe("Project-level override")
+    })
+
+    it("reads from .spores fallback when .agentic is absent", async () => {
+      await writeCapability(tmpDir, "issue_tracker.list_issues", VALID_CAPABILITY, ".spores")
+      const caps = await listCapabilities(tmpDir)
+      expect(caps).toHaveLength(1)
+      expect(caps[0]!.name).toBe("issue_tracker.list_issues")
+    })
+  })
+
+  describe("loadCapability", () => {
+    it("returns undefined when no capabilities dir exists", async () => {
+      const cap = await loadCapability("issue_tracker.list_issues", tmpDir)
+      expect(cap).toBeUndefined()
+    })
+
+    it("returns undefined for a missing name", async () => {
+      await writeCapability(tmpDir, "web.search", ANOTHER_CAPABILITY)
+      const cap = await loadCapability("not.there", tmpDir)
+      expect(cap).toBeUndefined()
+    })
+
+    it("returns the capability from the project dir", async () => {
+      await writeCapability(tmpDir, "issue_tracker.list_issues", VALID_CAPABILITY)
+      const cap = await loadCapability("issue_tracker.list_issues", tmpDir)
+      expect(cap).not.toBeUndefined()
+      expect(cap!.name).toBe("issue_tracker.list_issues")
+    })
+
+    it("returns the capability from the global dir", async () => {
+      const globalCapDir = join(fakeHome, ".agentic", "capabilities")
+      await mkdir(globalCapDir, { recursive: true })
+      await writeFile(join(globalCapDir, "web.search.json"), ANOTHER_CAPABILITY)
+      const cap = await loadCapability("web.search", tmpDir)
+      expect(cap).not.toBeUndefined()
+      expect(cap!.name).toBe("web.search")
+    })
+
+    it("project takes precedence over global on name conflict", async () => {
+      const projectVersion = JSON.stringify({
+        name: "web.search",
+        description: "Project wins",
+        policy: { effects: ["external.read"] },
+      })
+      await writeCapability(tmpDir, "web.search", projectVersion)
+
+      const globalCapDir = join(fakeHome, ".agentic", "capabilities")
+      await mkdir(globalCapDir, { recursive: true })
+      await writeFile(join(globalCapDir, "web.search.json"), ANOTHER_CAPABILITY)
+
+      const cap = await loadCapability("web.search", tmpDir)
+      expect(cap!.description).toBe("Project wins")
+    })
+
+    it("returns undefined for malformed JSON in project dir", async () => {
+      const capDir = join(tmpDir, ".agentic", "capabilities")
+      await mkdir(capDir, { recursive: true })
+      await writeFile(join(capDir, "bad.json"), "{ invalid json")
+      const cap = await loadCapability("bad", tmpDir)
+      expect(cap).toBeUndefined()
+    })
+  })
+})

--- a/src/capability/filesystem.ts
+++ b/src/capability/filesystem.ts
@@ -1,0 +1,108 @@
+import { join } from "node:path"
+import { resolveProjectDir, resolveGlobalDir } from "../resolve-dir.js"
+import type { CapabilityDef } from "../types.js"
+import type { Source } from "../sources/source.js"
+import { LayeredSource } from "../sources/layered.js"
+import { FlatFileSource } from "../sources/flat-file.js"
+import { validateCapability } from "./helpers.js"
+
+// ---------------------------------------------------------------------------
+// JSON parser — dependency-free
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a capability declaration from raw JSON text. Returns `undefined` for
+ * malformed JSON or a declaration that fails structural validation — matching
+ * the "return undefined rather than throw" convention of the skill loader.
+ */
+function parseCapability(text: string): CapabilityDef | undefined {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(text)
+  } catch {
+    return undefined
+  }
+  const result = validateCapability(parsed)
+  if (!result.valid) return undefined
+  return parsed as CapabilityDef
+}
+
+// ---------------------------------------------------------------------------
+// Source-based API — works with any pluggable Source
+// ---------------------------------------------------------------------------
+
+/**
+ * List all capabilities exposed by the given source. Skips records whose
+ * JSON is malformed or fails validation — those are surfaced quietly rather
+ * than throwing, matching `loadCapabilityFromSource`'s "return undefined for
+ * malformed" semantics.
+ */
+export async function listCapabilitiesFromSource(
+  source: Source,
+): Promise<CapabilityDef[]> {
+  const names = await source.list()
+  const defs: CapabilityDef[] = []
+
+  for (const name of names) {
+    const record = await source.read(name)
+    if (record === undefined) continue
+
+    const def = parseCapability(record.text)
+    if (def !== undefined) defs.push(def)
+  }
+
+  return defs.sort((a, b) => a.name.localeCompare(b.name))
+}
+
+/**
+ * Load a single capability by name from a source. Returns `undefined` if
+ * the name is not found or the declaration is malformed.
+ */
+export async function loadCapabilityFromSource(
+  name: string,
+  source: Source,
+): Promise<CapabilityDef | undefined> {
+  const record = await source.read(name)
+  if (record === undefined) return undefined
+  return parseCapability(record.text)
+}
+
+// ---------------------------------------------------------------------------
+// Convenience API — filesystem layering of project + global capabilities
+// ---------------------------------------------------------------------------
+
+function globalCapabilitiesDir(): string {
+  return resolveGlobalDir("capabilities")
+}
+
+function projectCapabilitiesDir(baseDir: string): string {
+  return resolveProjectDir(baseDir, "capabilities")
+}
+
+function defaultFilesystemSource(baseDir: string): Source {
+  return new LayeredSource([
+    new FlatFileSource(projectCapabilitiesDir(baseDir), ".json"),
+    new FlatFileSource(globalCapabilitiesDir(), ".json"),
+  ])
+}
+
+/**
+ * List all available capabilities. Project capabilities
+ * (`.agentic/capabilities/`) override global capabilities
+ * (`~/.agentic/capabilities/`) when names conflict. `.spores/` directories
+ * are used as a fallback for legacy projects.
+ */
+export async function listCapabilities(baseDir: string): Promise<CapabilityDef[]> {
+  return listCapabilitiesFromSource(defaultFilesystemSource(baseDir))
+}
+
+/**
+ * Load a capability by name. Returns `undefined` if not found.
+ * Project capabilities take precedence over global capabilities.
+ */
+export async function loadCapability(
+  name: string,
+  baseDir: string,
+): Promise<CapabilityDef | undefined> {
+  return loadCapabilityFromSource(name, defaultFilesystemSource(baseDir))
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,6 +123,12 @@ export {
   capabilityMatchesDispatch,
   capabilityRequiresApprovalFor,
 } from "./capability/helpers.js"
+export {
+  listCapabilitiesFromSource,
+  loadCapabilityFromSource,
+  listCapabilities,
+  loadCapability,
+} from "./capability/filesystem.js"
 
 export { fireHook } from "./hooks/fire.js"
 


### PR DESCRIPTION
Closes #71.

## Summary

- `listCapabilitiesFromSource(source)` / `loadCapabilityFromSource(name, source)` — pluggable Source-backed loaders; malformed JSON or invalid declarations return `undefined` rather than throwing, matching existing skill/persona loader behavior
- `listCapabilities(baseDir)` / `loadCapability(name, baseDir)` — filesystem convenience API with project-overrides-global layering
- Declaration format is JSON (`JSON.parse` — dependency-free); `FlatFileSource` with `.json` extension handles enumeration and reads
- `.agentic/capabilities/` preferred; `.spores/capabilities/` preserved as legacy fallback via `resolveProjectDir` / `resolveGlobalDir`

## Tests (22 new, 563 total — all pass)

- Source loading: round-trip read, list, sorted output
- Malformed records: invalid JSON skipped in list, returns `undefined` on load
- Missing records: `undefined` returned, no throw
- Filesystem layering: project + global merge; project overrides global on name conflict
- Legacy `.spores/` fallback path

## Acceptance criteria coverage

| Criterion | Covered by |
|---|---|
| Project overrides user on name conflict | `listCapabilities` / `loadCapability` layering tests |
| Missing → `undefined`, no throw | `loadCapabilityFromSource` missing test; `listCapabilities` empty dir test |
| Malformed → consistent with skill loader | `loadCapabilityFromSource` malformed JSON / invalid validation tests; `listCapabilitiesFromSource` skips tests |
| Source loading, filesystem layering, missing, malformed, precedence | All 22 tests |