### PR TITLE
feat(cli): add capability list/show/validate commands

### DIFF
--- a/src/cli/commands/capability.test.ts
+++ b/src/cli/commands/capability.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test"
+import { mkdtemp, rm, mkdir, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import {
+  capabilityListCommand,
+  capabilityShowCommand,
+  capabilityValidateCommand,
+} from "./capability.js"
+import type { Ctx } from "../context.js"
+import type { SporesConfig } from "../../types.js"
+import { FilesystemAdapter } from "../../memory/filesystem.js"
+
+function makeCtx(baseDir: string): Ctx {
+  const config: SporesConfig = {
+    adapter: "filesystem",
+    memory: { dir: ".spores/memory", defaultTier: "L1", dreamDepth: 1 },
+    workflow: {
+      graphsDir: ".spores/workflow/graphs",
+      runsDir: ".spores/workflow/runs",
+    },
+    wake: {},
+  }
+  return {
+    adapter: new FilesystemAdapter(baseDir),
+    config,
+    baseDir,
+    json: true,
+    wide: false,
+  }
+}
+
+function captureStdout(fn: () => Promise<void>): Promise<string> {
+  const origLog = console.log
+  let captured = ""
+  console.log = (...args: unknown[]) => {
+    captured +=
+      args.map((a) => (typeof a === "string" ? a : String(a))).join(" ") + "\n"
+  }
+  return fn()
+    .then(() => captured)
+    .finally(() => {
+      console.log = origLog
+    })
+}
+
+async function writeCapability(
+  baseDir: string,
+  name: string,
+  json: object,
+  subdir: ".agentic" | ".spores" = ".agentic",
+): Promise<void> {
+  const capDir = join(baseDir, subdir, "capabilities")
+  await mkdir(capDir, { recursive: true })
+  await writeFile(join(capDir, `${name}.json`), JSON.stringify(json))
+}
+
+const ISSUE_CAP = {
+  name: "issue_tracker.list_issues",
+  description: "List issues from an external issue tracker.",
+  skill: "issue-triage",
+  requires: {
+    connections: [{ provider: "issue_tracker", capabilities: ["issues.read"] }],
+  },
+  policy: { effects: ["external.read"] },
+}
+
+const SEARCH_CAP = {
+  name: "web.search",
+  description: "Search the web.",
+  policy: { effects: ["external.read"] },
+}
+
+describe("capability CLI commands", () => {
+  let tmpDir: string
+  let ctx: Ctx
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "spores-capability-cli-"))
+    ctx = makeCtx(tmpDir)
+  })
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  // ---------------------------------------------------------------------------
+  // capability list
+  // ---------------------------------------------------------------------------
+
+  it("capability list returns empty array when no capabilities exist", async () => {
+    const out = await captureStdout(() => capabilityListCommand(ctx, [], {}))
+    const defs = JSON.parse(out)
+    expect(Array.isArray(defs)).toBe(true)
+    expect(defs.length).toBe(0)
+  })
+
+  it("capability list returns all capabilities sorted by name", async () => {
+    await writeCapability(tmpDir, "web.search", SEARCH_CAP)
+    await writeCapability(tmpDir, "issue_tracker.list_issues", ISSUE_CAP)
+    const out = await captureStdout(() => capabilityListCommand(ctx, [], {}))
+    const defs = JSON.parse(out)
+    expect(defs.length).toBe(2)
+    expect(defs[0].name).toBe("issue_tracker.list_issues")
+    expect(defs[1].name).toBe("web.search")
+  })
+
+  it("capability list skips malformed JSON files", async () => {
+    await writeCapability(tmpDir, "good", SEARCH_CAP)
+    const capDir = join(tmpDir, ".agentic", "capabilities")
+    await writeFile(join(capDir, "bad.json"), "not-json")
+    const out = await captureStdout(() => capabilityListCommand(ctx, [], {}))
+    const defs = JSON.parse(out)
+    expect(defs.length).toBe(1)
+    expect(defs[0].name).toBe("web.search")
+  })
+
+  // ---------------------------------------------------------------------------
+  // capability show
+  // ---------------------------------------------------------------------------
+
+  it("capability show requires a name argument", async () => {
+    await expect(capabilityShowCommand(ctx, [], {})).rejects.toThrow(/Usage/)
+  })
+
+  it("capability show loads a capability by name", async () => {
+    await writeCapability(tmpDir, "issue_tracker.list_issues", ISSUE_CAP)
+    const out = await captureStdout(() =>
+      capabilityShowCommand(ctx, ["issue_tracker.list_issues"], {}),
+    )
+    const def = JSON.parse(out)
+    expect(def.name).toBe("issue_tracker.list_issues")
+    expect(def.description).toBe("List issues from an external issue tracker.")
+    expect(def.skill).toBe("issue-triage")
+  })
+
+  it("capability show throws not-found for unknown capability", async () => {
+    await expect(
+      capabilityShowCommand(ctx, ["no.such.cap"], {}),
+    ).rejects.toThrow(/Capability not found/)
+  })
+
+  it("capability show includes policy and connections in JSON output", async () => {
+    await writeCapability(tmpDir, "issue_tracker.list_issues", ISSUE_CAP)
+    const out = await captureStdout(() =>
+      capabilityShowCommand(ctx, ["issue_tracker.list_issues"], {}),
+    )
+    const def = JSON.parse(out)
+    expect(def.policy?.effects).toContain("external.read")
+    expect(def.requires?.connections?.[0]?.provider).toBe("issue_tracker")
+  })
+
+  // ---------------------------------------------------------------------------
+  // capability validate — by name
+  // ---------------------------------------------------------------------------
+
+  it("capability validate requires a name-or-file argument", async () => {
+    await expect(capabilityValidateCommand(ctx, [], {})).rejects.toThrow(/Usage/)
+  })
+
+  it("capability validate reports valid for a well-formed capability name", async () => {
+    await writeCapability(tmpDir, "web.search", SEARCH_CAP)
+    const out = await captureStdout(() =>
+      capabilityValidateCommand(ctx, ["web.search"], {}),
+    )
+    const result = JSON.parse(out)
+    expect(result.valid).toBe(true)
+    expect(result.subject).toBe("web.search")
+    expect(result.capability).toBeDefined()
+  })
+
+  it("capability validate throws not-found for unknown capability name", async () => {
+    await expect(
+      capabilityValidateCommand(ctx, ["no.such.cap"], {}),
+    ).rejects.toThrow(/Capability not found/)
+  })
+
+  it("capability validate reports errors for an invalid declaration by name", async () => {
+    const capDir = join(tmpDir, ".agentic", "capabilities")
+    await mkdir(capDir, { recursive: true })
+    // name field is missing — should fail validation
+    await writeFile(join(capDir, "bad-cap.json"), JSON.stringify({ description: "oops" }))
+    const out = await captureStdout(() =>
+      capabilityValidateCommand(ctx, ["bad-cap"], {}),
+    )
+    const result = JSON.parse(out)
+    expect(result.valid).toBe(false)
+    expect(result.errors.length).toBeGreaterThan(0)
+    expect(result.errors[0].field).toBe("name")
+  })
+
+  // ---------------------------------------------------------------------------
+  // capability validate — by file path
+  // ---------------------------------------------------------------------------
+
+  it("capability validate accepts a file path ending in .json", async () => {
+    const filePath = join(tmpDir, "my-cap.json")
+    await writeFile(filePath, JSON.stringify(ISSUE_CAP))
+    const out = await captureStdout(() =>
+      capabilityValidateCommand(ctx, [filePath], {}),
+    )
+    const result = JSON.parse(out)
+    expect(result.valid).toBe(true)
+    expect(result.subject).toBe(filePath)
+  })
+
+  it("capability validate reports invalid JSON for a malformed file", async () => {
+    const filePath = join(tmpDir, "bad.json")
+    await writeFile(filePath, "not valid json")
+    const out = await captureStdout(() =>
+      capabilityValidateCommand(ctx, [filePath], {}),
+    )
+    const result = JSON.parse(out)
+    expect(result.valid).toBe(false)
+    expect(result.errors[0].message).toContain("not valid JSON")
+  })
+
+  it("capability validate throws for a missing file path", async () => {
+    const filePath = join(tmpDir, "nonexistent.json")
+    await expect(
+      capabilityValidateCommand(ctx, [filePath], {}),
+    ).rejects.toThrow(/File not found/)
+  })
+
+  it("capability validate reports validation errors for an invalid file", async () => {
+    const filePath = join(tmpDir, "invalid-cap.json")
+    await writeFile(
+      filePath,
+      JSON.stringify({
+        name: "test.cap",
+        policy: { effects: ["unknown_effect_xyz"] },
+      }),
+    )
+    const out = await captureStdout(() =>
+      capabilityValidateCommand(ctx, [filePath], {}),
+    )
+    const result = JSON.parse(out)
+    expect(result.valid).toBe(false)
+    expect(result.errors.some((e: { field: string }) => e.field.startsWith("policy.effects"))).toBe(true)
+  })
+
+  // ---------------------------------------------------------------------------
+  // Human-mode formatters (smoke test)
+  // ---------------------------------------------------------------------------
+
+  it("capability list produces human-readable table in non-JSON mode", async () => {
+    await writeCapability(tmpDir, "web.search", SEARCH_CAP)
+    const humanCtx = { ...ctx, json: false }
+    const out = await captureStdout(() => capabilityListCommand(humanCtx, [], {}))
+    expect(out).toContain("NAME")
+    expect(out).toContain("web.search")
+  })
+
+  it("capability show produces human-readable output in non-JSON mode", async () => {
+    await writeCapability(tmpDir, "web.search", SEARCH_CAP)
+    const humanCtx = { ...ctx, json: false }
+    const out = await captureStdout(() =>
+      capabilityShowCommand(humanCtx, ["web.search"], {}),
+    )
+    expect(out).toContain("web.search")
+    expect(out).toContain("Search the web.")
+  })
+
+  it("capability validate shows valid line in non-JSON mode", async () => {
+    await writeCapability(tmpDir, "web.search", SEARCH_CAP)
+    const humanCtx = { ...ctx, json: false }
+    const out = await captureStdout(() =>
+      capabilityValidateCommand(humanCtx, ["web.search"], {}),
+    )
+    expect(out).toContain("web.search")
+    expect(out).toContain("valid")
+  })
+})

--- a/src/cli/commands/capability.ts
+++ b/src/cli/commands/capability.ts
@@ -1,0 +1,103 @@
+import { readFile } from "node:fs/promises"
+import type { CapabilityDef } from "../../types.js"
+import { listCapabilities, loadCapability } from "../../capability/filesystem.js"
+import { validateCapability } from "../../capability/helpers.js"
+import { FlatFileSource } from "../../sources/flat-file.js"
+import { LayeredSource } from "../../sources/layered.js"
+import { resolveProjectDir, resolveGlobalDir } from "../../resolve-dir.js"
+import {
+  formatCapabilityDefs,
+  formatCapabilityDef,
+  formatCapabilityValidate,
+} from "../format.js"
+import type { CapabilityValidateResult } from "../format.js"
+import type { Command } from "../context.js"
+import { output } from "../output.js"
+
+export type { CapabilityValidateResult }
+
+export const capabilityListCommand: Command = async (ctx, _args, _flags) => {
+  const defs = await listCapabilities(ctx.baseDir)
+  output(ctx, defs, (data) => formatCapabilityDefs(data, ctx.wide))
+}
+
+export const capabilityShowCommand: Command = async (ctx, args, _flags) => {
+  const name = args[0]
+  if (name === undefined) throw new Error("Usage: capability show <name>")
+
+  const def = await loadCapability(name, ctx.baseDir)
+  if (def === undefined) throw new Error(`Capability not found: ${name}`)
+
+  output(ctx, def, formatCapabilityDef)
+}
+
+export const capabilityValidateCommand: Command = async (ctx, args, _flags) => {
+  const subject = args[0]
+  if (subject === undefined)
+    throw new Error("Usage: capability validate <name-or-file>")
+
+  let result: CapabilityValidateResult
+
+  if (subject.includes("/") || subject.endsWith(".json")) {
+    // File path — read directly
+    let text: string
+    try {
+      text = await readFile(subject, "utf-8")
+    } catch {
+      throw new Error(`File not found: ${subject}`)
+    }
+
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(text)
+    } catch {
+      result = {
+        subject,
+        valid: false,
+        errors: [{ field: ".", message: "file is not valid JSON" }],
+      }
+      output(ctx, result, formatCapabilityValidate)
+      return
+    }
+
+    const validation = validateCapability(parsed)
+    if (validation.valid) {
+      result = { subject, valid: true, capability: parsed as CapabilityDef }
+    } else {
+      result = { subject, valid: false, errors: validation.errors }
+    }
+  } else {
+    // Capability name — read via the same layered source used by loadCapability
+    const source = new LayeredSource([
+      new FlatFileSource(resolveProjectDir(ctx.baseDir, "capabilities"), ".json"),
+      new FlatFileSource(resolveGlobalDir("capabilities"), ".json"),
+    ])
+
+    const record = await source.read(subject)
+    if (record === undefined) {
+      throw new Error(`Capability not found: ${subject}`)
+    }
+
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(record.text)
+    } catch {
+      result = {
+        subject,
+        valid: false,
+        errors: [{ field: ".", message: "declaration is not valid JSON" }],
+      }
+      output(ctx, result, formatCapabilityValidate)
+      return
+    }
+
+    const validation = validateCapability(parsed)
+    if (validation.valid) {
+      result = { subject, valid: true, capability: parsed as CapabilityDef }
+    } else {
+      result = { subject, valid: false, errors: validation.errors }
+    }
+  }
+
+  output(ctx, result, formatCapabilityValidate)
+}

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -35,6 +35,7 @@ import type {
   ArtifactEditedOutput,
   ArtifactLockedOutput,
   ArtifactInspectedOutput,
+  CapabilityDef,
 } from "../types.js"
 
 
@@ -529,4 +530,84 @@ export function formatArtifactList(refs: ArtifactRef[]): string {
       r.locked ? "yes" : "no",
     ]),
   )
+}
+
+// ---------------------------------------------------------------------------
+// Capability formatters
+// ---------------------------------------------------------------------------
+
+/**
+ * Structured result from `capability validate`. Defined here (not in
+ * capability.ts) to avoid a circular import: the formatter must reference
+ * this type and capability.ts imports from format.ts.
+ */
+export type CapabilityValidateResult =
+  | { subject: string; valid: true; capability: CapabilityDef }
+  | { subject: string; valid: false; errors: { field: string; message: string }[] }
+
+/** Human formatter for `capability list`. */
+export function formatCapabilityDefs(defs: CapabilityDef[], wide = false): string {
+  if (defs.length === 0) return "No capabilities found."
+  return table(
+    ["NAME", "DESCRIPTION", "EFFECTS"],
+    defs.map((d) => {
+      const effects = d.policy?.effects?.join(", ") ?? ""
+      const desc = d.description ?? ""
+      return [d.name, wide ? desc : trunc(desc), effects]
+    }),
+  )
+}
+
+/** Human formatter for `capability show`. */
+export function formatCapabilityDef(def: CapabilityDef): string {
+  const lines: string[] = []
+  lines.push(def.name)
+  if (def.description !== undefined) lines.push(`  ${def.description}`)
+  if (def.skill !== undefined) lines.push(`  skill: ${def.skill}`)
+  const conns = def.requires?.connections
+  if (conns !== undefined && conns.length > 0) {
+    lines.push("  requires:")
+    lines.push("    connections:")
+    for (const c of conns) {
+      lines.push(`      - provider: ${c.provider}  capabilities: ${c.capabilities.join(", ")}`)
+    }
+  }
+  const policy = def.policy
+  if (policy !== undefined) {
+    lines.push("  policy:")
+    if (policy.effects !== undefined && policy.effects.length > 0) {
+      lines.push(`    effects: ${policy.effects.join(", ")}`)
+    }
+    if (policy.tools !== undefined && policy.tools.length > 0) {
+      lines.push(`    tools: ${policy.tools.join(", ")}`)
+    }
+    if (policy.approval !== undefined) {
+      lines.push(`    approval:`)
+      lines.push(`      mode: ${policy.approval.mode}`)
+      lines.push(`      required_for: ${policy.approval.required_for.join(", ")}`)
+    }
+    if (policy.dispatch !== undefined) {
+      lines.push(`    dispatch: ${JSON.stringify(policy.dispatch)}`)
+    }
+  }
+  const artifacts = def.artifacts
+  if (artifacts !== undefined) {
+    lines.push("  artifacts:")
+    if (artifacts.reads !== undefined && artifacts.reads.length > 0) {
+      lines.push(`    reads: ${artifacts.reads.join(", ")}`)
+    }
+    if (artifacts.writes !== undefined && artifacts.writes.length > 0) {
+      lines.push(`    writes: ${artifacts.writes.join(", ")}`)
+    }
+  }
+  return lines.join("\n")
+}
+
+/** Human formatter for `capability validate`. */
+export function formatCapabilityValidate(result: CapabilityValidateResult): string {
+  if (result.valid) {
+    return `${result.subject}: valid`
+  }
+  const errorLines = result.errors.map((e) => `  ${e.field}: ${e.message}`)
+  return [`${result.subject}: invalid`, ...errorLines].join("\n")
 }

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -54,6 +54,11 @@ import {
   artifactListCommand,
   artifactLockCommand,
 } from "./commands/artifact.js"
+import {
+  capabilityListCommand,
+  capabilityShowCommand,
+  capabilityValidateCommand,
+} from "./commands/capability.js"
 
 type Parsed = {
   positional: string[]
@@ -128,6 +133,9 @@ const commands: Record<string, Command> = {
   "artifact inspect": artifactInspectCommand,
   "artifact list": artifactListCommand,
   "artifact lock": artifactLockCommand,
+  "capability list": capabilityListCommand,
+  "capability show": capabilityShowCommand,
+  "capability validate": capabilityValidateCommand,
   wake: wakeCommand,
 }
 
@@ -177,6 +185,10 @@ Commands:
   artifact inspect <id>               Show artifact metadata
   artifact list                       List artifacts (filter with flags)
   artifact lock <id>                  Lock an artifact (append-only)
+
+  capability list                     List available capabilities
+  capability show <name>              Show capability declaration details
+  capability validate <name-or-file>  Validate a capability by name or file path
 
   wake                                Session bootstrap — identity, environment, personas
 


### PR DESCRIPTION
Closes #72.

## Summary

- `capability list` — lists all capabilities from the layered filesystem source (project + global), table-formatted with NAME / DESCRIPTION / EFFECTS columns; `--json` returns the raw `CapabilityDef[]`
- `capability show <name>` — shows full declaration details (description, skill ref, connections, policy, artifacts); throws a clear `Capability not found: <name>` error for missing names
- `capability validate <name-or-file>` — validates a capability by name (reads raw declaration text through the same layered source to surface field-level errors) or by direct file path; `--json` returns `{ subject, valid, capability? | errors? }`
- Commands mirror existing skill / persona list/show style
- No execution, provider, or runtime behavior introduced

## Implementation notes

- `CapabilityValidateResult` type defined in `src/cli/format.ts` (not `capability.ts`) to avoid a circular import: the formatter references the type and `capability.ts` imports from `format.ts`
- Validate by-name reconstructs the layered source directly in the command rather than adding internal exports to the library — CLI is not a library consumer, duplication is 5 lines

## Tests (18 new, 581 total — all pass)

| Area | Tests |
|---|---|
| `capability list` — empty, sorted, skips malformed | 3 |
| `capability show` — loads, not-found, JSON fields | 3 |
| `capability validate` — by name: valid, not-found, invalid fields | 3 |
| `capability validate` — by file path: valid, malformed JSON, missing, invalid | 4 |
| Human-mode formatter smoke tests (list/show/validate) | 3 |
| Argument guard (`Usage:` errors) | 2 |

## Acceptance criteria coverage

| Criterion | Covered by |
|---|---|
| Human output readable / table-like | `formatCapabilityDefs` table; `formatCapabilityDef` detail view |
| `--json` returns structured declarations and validation results | All JSON-mode tests |
| `show` returns clear not-found error | `capabilityShowCommand` + test |
| `validate` validates a loaded capability and a direct file path | By-name + by-file-path tests |
| No command executes a capability or invokes provider/runtime behavior | Scope held throughout |