### PR TITLE
fix: non-null assertion for indexed FIXTURES access

### DIFF
--- a/src/capability/catalog.test.ts
+++ b/src/capability/catalog.test.ts
@@ -146,7 +146,7 @@ describe("catalog: declarations validate", () => {
 
   it("malformed JSON from source is skipped by listCapabilitiesFromSource", async () => {
     const source = new InMemorySource({
-      "good_cap": FIXTURES["web.search"],
+      "good_cap": FIXTURES["web.search"]!,
       "bad_json": "{ not valid json",
     })
     const caps = await listCapabilitiesFromSource(source)


### PR DESCRIPTION
CI typecheck on `main` is failing because `noUncheckedIndexedAccess` makes `FIXTURES['web.search']` return `string | undefined`. This adds a non-null assertion since the fixture is known to exist in the test context.

Single-line change, all 32 catalog tests pass locally. Safe to auto-merge on green CI.