### PR TITLE
feat(artifact): rename lock to finalize

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ A TypeScript library + CLI for agent in-loop primitives:
 3. **Workflow** — digraph runtime (GraphDef → Run → Transitions, state derived from history)
 4. **Tasks** — typed adapter interface (ULID IDs, Taskwarrior-shaped)
 5. **Persona** — activate a hat at the start of a turn: metadata (memory_tags, skills, task_filter, workflow, routing hints) + a rendered body with live situational facts. Declarative attention, not enforced scope.
-6. **Artifact** — versioned content blobs with metadata (type, title, tags, lock). The canonical place to store an agent's durable outputs within a project — briefs, memos, reports, plans. See "Artifact primitive" below.
+6. **Artifact** — versioned content blobs with metadata (type, title, tags, finalized). The canonical place to store an agent's durable outputs within a project — briefs, memos, reports, plans. See "Artifact primitive" below.
 7. **Source** — pluggable read-only loader abstraction (`read(name) → text`, `list() → names`). Personas/skills/workflows all load through the same shape. `LayeredSource` composes for seed-then-emerge (e.g. live DB shadows seed filesystem). See "Source abstraction" below.
 8. **Dispatch** — foundation types for the universal inbound message primitive (`Dispatch`, `DispatchFilter`, `matchDispatch`). Spores ships the message shape and pure match logic; runtimes ship transport, scheduling, and handler execution.
 
@@ -92,7 +92,7 @@ Current command surface:
 - `agentic skill list/show/run`
 - `agentic workflow list/show/run/status`
 - `agentic persona list/view/activate`
-- `agentic artifact create/read/write/edit/inspect/list/lock`
+- `agentic artifact create/read/write/edit/inspect/list/finalize`
 
 ### Skills on disk
 
@@ -162,7 +162,7 @@ Artifacts are versioned markdown blobs — the agent's durable output store for 
 **On-disk layout** (inside `.agentic/artifacts/`):
 
 ```
-.agentic/artifacts/<ulid>/meta.json    — ArtifactRecord (type, title, version, locked, tags, …)
+.agentic/artifacts/<ulid>/meta.json    — ArtifactRecord (type, title, version, finalized, tags, …)
 .agentic/artifacts/<ulid>/v1.md        — body at version 1
 .agentic/artifacts/<ulid>/v2.md        — body at version 2 (iterate write)
 ```
@@ -178,7 +178,7 @@ Legacy: `.spores/artifacts/` is used when `.agentic/artifacts/` does not exist.
 | `replace` | Overwrite current `v<n>.md` in place. Version unchanged. |
 | `create` | Fail with "already exists". Used only for first-write semantics. |
 
-**Lock semantics:** `artifact lock <id>` sets `locked=true` in `meta.json`. Locked artifacts reject `write` and `edit`. `lock` is idempotent — locking an already-locked artifact is a no-op.
+**Finalize semantics:** `artifact finalize <id>` sets `finalized=true` in `meta.json`. Finalized artifacts reject `write` and `edit`. `finalize` is idempotent — finalizing an already-finalized artifact is a no-op.
 
 **CLI worked example:**
 
@@ -201,8 +201,8 @@ agentic artifact inspect 01JXYZ... --json
 # List with filter
 agentic artifact list --type brief --json
 
-# Lock the final version
-agentic artifact lock 01JXYZ...
+# Finalize the artifact
+agentic artifact finalize 01JXYZ...
 ```
 
 **Hook events:**
@@ -211,9 +211,9 @@ agentic artifact lock 01JXYZ...
 |-------|---------|
 | `artifact.created` | `artifact create` |
 | `artifact.written` | `artifact write`, `artifact edit` |
-| `artifact.locked` | `artifact lock` |
+| `artifact.finalized` | `artifact finalize` |
 
-Hook env vars: `AGENTIC_ARTIFACT_ID`, `AGENTIC_ARTIFACT_TYPE`, `AGENTIC_ARTIFACT_TITLE`, `AGENTIC_ARTIFACT_TAGS` (create); `AGENTIC_ARTIFACT_ID`, `AGENTIC_ARTIFACT_VERSION`, `AGENTIC_ARTIFACT_MODE` (written); `AGENTIC_ARTIFACT_ID`, `AGENTIC_ARTIFACT_FINAL_VERSION` (locked). Legacy `SPORES_*` mirrors are set alongside for compatibility.
+Hook env vars: `AGENTIC_ARTIFACT_ID`, `AGENTIC_ARTIFACT_TYPE`, `AGENTIC_ARTIFACT_TITLE`, `AGENTIC_ARTIFACT_TAGS` (create); `AGENTIC_ARTIFACT_ID`, `AGENTIC_ARTIFACT_VERSION`, `AGENTIC_ARTIFACT_MODE` (written); `AGENTIC_ARTIFACT_ID`, `AGENTIC_ARTIFACT_FINAL_VERSION` (finalized). Legacy `SPORES_*` mirrors are set alongside for compatibility.
 
 **Dogfood hook:** `.agentic/hooks/artifact.written` — indexes the artifact reference into memory after every write so it's searchable via `agentic memory recall`.
 

--- a/docs/framework-boundaries.md
+++ b/docs/framework-boundaries.md
@@ -26,7 +26,7 @@ Recent production-host usage has validated several reusable concepts without mak
 - Skills need a way to reference executable capability contracts without becoming executors themselves.
 - Capability declarations need portable policy vocabulary for effects, approval requirements, dispatch constraints, artifacts, and connection requirements.
 - Human-in-the-loop approval is a first-class host-runtime requirement, but Agentic's role is to declare where approval is required rather than implement the approval flow.
-- Artifacts are a real primitive: agents produce durable outputs that benefit from versioning, locking, and typed metadata.
+- Artifacts are a real primitive: agents produce durable outputs that benefit from versioning, finalization, and typed metadata.
 - Personas are useful as active hats: they declare memory tags, skills, task filters, workflow hints, and model-facing instructions.
 - Task queues are useful in-loop, but external work trackers are host integrations rather than core package adapters.
 - Lifecycle events are useful integration seams, but event handling belongs to the host or harness.
@@ -41,7 +41,7 @@ Recent production-host usage has validated several reusable concepts without mak
 | Workflow | Graphs, runs, transitions, state derived from history | Scheduling, wakeups, lifecycle ownership, long-running process management |
 | Tasks | Task shape, adapter interface, local queue semantics | External trackers, assignment policy, board stewardship, async workers |
 | Persona | Declarative active-hat metadata and rendered body | Identity, session ownership, authorization, automatic application of defaults |
-| Artifacts | Versioned content blobs, metadata, lock/write semantics | UI rendering, collaboration, inboxes, external delivery, attachment APIs |
+| Artifacts | Versioned content blobs, metadata, finalize/write semantics | UI rendering, collaboration, inboxes, external delivery, attachment APIs |
 | Sources | Read-only loader abstraction and composition | Remote storage, deployment, synchronization, access control |
 | Capabilities | Portable declarations and pure policy helpers | Provider clients, credentials, approval UI, enforcement, audit logs |
 | Dispatch | Message shape, filters, and pure match logic | Webhooks, queues, recurrence, transport, handler execution |
@@ -111,7 +111,7 @@ Agentic should not define a telemetry backend, trace store, dashboard, or progre
 Useful event seams include:
 
 - A workflow transitioned.
-- An artifact was written or locked.
+- An artifact was written or finalized.
 - A capability was requested, allowed, denied, or completed.
 - Approval was requested, granted, rejected, or expired.
 - A memory was written or reinforced.
@@ -188,7 +188,7 @@ Examples of semantic lifecycle events:
 
 - `artifact.created`
 - `artifact.written`
-- `artifact.locked`
+- `artifact.finalized`
 - `persona.activated`
 - `workflow.transitioned`
 - `memory.remembered`

--- a/docs/lifecycle-events.md
+++ b/docs/lifecycle-events.md
@@ -29,7 +29,7 @@ Initial semantic events:
 
 - `artifact.created`
 - `artifact.written`
-- `artifact.locked`
+- `artifact.finalized`
 - `persona.activated`
 - `workflow.transitioned`
 - `memory.remembered`

--- a/src/artifact/adapter.ts
+++ b/src/artifact/adapter.ts
@@ -24,14 +24,14 @@ export interface WriteArtifactInput {
  * Adapter interface for durable artifact storage.
  *
  * An artifact is a named, versioned piece of content — addressable by ULID,
- * persistable across turns, lockable for append-only history.
+ * persistable across turns, finalizable into read-only history.
  *
  * Storage implementations (filesystem, blob) are separate from this interface.
  * The filesystem adapter (`FilesystemArtifactAdapter`) is the default.
  */
 export interface ArtifactAdapter {
   /**
-   * Create a new artifact. `id`, `version`, `locked`, `created_at`, and
+   * Create a new artifact. `id`, `version`, `finalized`, `created_at`, and
    * `updated_at` are set by the adapter.
    */
   create(input: CreateArtifactInput): Promise<ArtifactRecord>
@@ -48,7 +48,7 @@ export interface ArtifactAdapter {
    * - `replace` — overwrite current version in place
    * - `create` — fail if the artifact already exists
    *
-   * Fails if the artifact is locked.
+   * Fails if the artifact is finalized.
    */
   write(id: ArtifactId, input: WriteArtifactInput): Promise<ArtifactRecord>
 
@@ -56,7 +56,7 @@ export interface ArtifactAdapter {
    * Edit artifact body by replacing `oldStr` with `newStr`.
    * Semantically equivalent to a `write` with mode `iterate`.
    * Throws if `oldStr` is not found in the current body.
-   * Fails if the artifact is locked.
+   * Fails if the artifact is finalized.
    */
   edit(id: ArtifactId, oldStr: string, newStr: string): Promise<ArtifactRecord>
 
@@ -73,9 +73,9 @@ export interface ArtifactAdapter {
   list(query?: ArtifactQuery): Promise<ArtifactRef[]>
 
   /**
-   * Lock an artifact — transitions it to append-only.
-   * `write` and `edit` will fail on locked artifacts.
-   * Idempotent: locking an already-locked artifact is a no-op.
+   * Finalize an artifact — transitions it to read-only.
+   * `write` and `edit` will fail on finalized artifacts.
+   * Idempotent: finalizing an already-finalized artifact is a no-op.
    */
-  lock(id: ArtifactId): Promise<ArtifactRecord>
+  finalize(id: ArtifactId): Promise<ArtifactRecord>
 }

--- a/src/artifact/filesystem.test.ts
+++ b/src/artifact/filesystem.test.ts
@@ -22,7 +22,7 @@ describe("FilesystemArtifactAdapter", () => {
   // -------------------------------------------------------------------------
 
   describe("create", () => {
-    it("returns a record with ULID id, version=1, locked=false", async () => {
+    it("returns a record with ULID id, version=1, finalized=false", async () => {
       const record = await adapter.create({
         type: "brief",
         title: "Q2 Launch Brief",
@@ -32,7 +32,7 @@ describe("FilesystemArtifactAdapter", () => {
       expect(record.type).toBe("brief")
       expect(record.title).toBe("Q2 Launch Brief")
       expect(record.version).toBe(1)
-      expect(record.locked).toBe(false)
+      expect(record.finalized).toBe(false)
       expect(record.tags).toEqual([])
       expect(record.created_at).toBe(record.updated_at)
     })
@@ -163,12 +163,12 @@ describe("FilesystemArtifactAdapter", () => {
       })
     })
 
-    it("throws on locked artifact", async () => {
+    it("throws on finalized artifact", async () => {
       const record = await adapter.create({ type: "doc", title: "T", body: "body" })
-      await adapter.lock(record.id)
+      await adapter.finalize(record.id)
       await expect(
         adapter.write(record.id, { body: "update" }),
-      ).rejects.toThrow(/locked/i)
+      ).rejects.toThrow(/finalized/i)
     })
 
     it("throws on missing id", async () => {
@@ -202,12 +202,12 @@ describe("FilesystemArtifactAdapter", () => {
       ).rejects.toThrow(/not found/i)
     })
 
-    it("throws on locked artifact", async () => {
+    it("throws on finalized artifact", async () => {
       const record = await adapter.create({ type: "doc", title: "T", body: "content" })
-      await adapter.lock(record.id)
+      await adapter.finalize(record.id)
       await expect(
         adapter.edit(record.id, "content", "updated"),
-      ).rejects.toThrow(/locked/i)
+      ).rejects.toThrow(/finalized/i)
     })
   })
 
@@ -273,18 +273,18 @@ describe("FilesystemArtifactAdapter", () => {
       expect(q2orQ1.length).toBe(2)
     })
 
-    it("filters by locked=true", async () => {
+    it("filters by finalized=true", async () => {
       const a = await adapter.create({ type: "doc", title: "A", body: "a" })
       await adapter.create({ type: "doc", title: "B", body: "b" })
-      await adapter.lock(a.id)
+      await adapter.finalize(a.id)
 
-      const locked = await adapter.list({ locked: true })
-      expect(locked.length).toBe(1)
-      expect(locked[0]!.id).toBe(a.id)
+      const finalized = await adapter.list({ finalized: true })
+      expect(finalized.length).toBe(1)
+      expect(finalized[0]!.id).toBe(a.id)
 
-      const unlocked = await adapter.list({ locked: false })
-      expect(unlocked.length).toBe(1)
-      expect(unlocked[0]!.title).toBe("B")
+      const unfinalized = await adapter.list({ finalized: false })
+      expect(unfinalized.length).toBe(1)
+      expect(unfinalized[0]!.title).toBe("B")
     })
 
     it("returns lightweight refs (no body_ref)", async () => {
@@ -296,38 +296,38 @@ describe("FilesystemArtifactAdapter", () => {
       expect(refs[0]!.type).toBeDefined()
       expect(refs[0]!.title).toBeDefined()
       expect(refs[0]!.version).toBeDefined()
-      expect(refs[0]!.locked).toBeDefined()
+      expect(refs[0]!.finalized).toBeDefined()
     })
   })
 
   // -------------------------------------------------------------------------
-  // lock
+  // finalize
   // -------------------------------------------------------------------------
 
-  describe("lock", () => {
-    it("sets locked=true", async () => {
+  describe("finalize", () => {
+    it("sets finalized=true", async () => {
       const record = await adapter.create({ type: "doc", title: "T", body: "body" })
-      const locked = await adapter.lock(record.id)
-      expect(locked.locked).toBe(true)
+      const finalized = await adapter.finalize(record.id)
+      expect(finalized.finalized).toBe(true)
     })
 
-    it("persists the locked state", async () => {
+    it("persists the finalized state", async () => {
       const record = await adapter.create({ type: "doc", title: "T", body: "body" })
-      await adapter.lock(record.id)
+      await adapter.finalize(record.id)
       const meta = await adapter.inspect(record.id)
-      expect(meta.locked).toBe(true)
+      expect(meta.finalized).toBe(true)
     })
 
-    it("is idempotent — locking an already-locked artifact returns current record", async () => {
+    it("is idempotent — finalizing an already-finalized artifact returns current record", async () => {
       const record = await adapter.create({ type: "doc", title: "T", body: "body" })
-      const first = await adapter.lock(record.id)
-      const second = await adapter.lock(record.id)
-      expect(second.locked).toBe(true)
+      const first = await adapter.finalize(record.id)
+      const second = await adapter.finalize(record.id)
+      expect(second.finalized).toBe(true)
       expect(second.version).toBe(first.version)
     })
 
     it("throws on missing id", async () => {
-      await expect(adapter.lock("MISSING")).rejects.toThrow(/not found/i)
+      await expect(adapter.finalize("MISSING")).rejects.toThrow(/not found/i)
     })
   })
 })

--- a/src/artifact/filesystem.ts
+++ b/src/artifact/filesystem.ts
@@ -135,7 +135,7 @@ export class FilesystemArtifactAdapter implements ArtifactAdapter {
       title: input.title,
       body_ref: bodyRef,
       version: 1,
-      locked: false,
+      finalized: false,
       tags: input.tags ?? [],
       created_at: now,
       updated_at: now,
@@ -186,8 +186,8 @@ export class FilesystemArtifactAdapter implements ArtifactAdapter {
     const record = await this.loadMeta(id)
     const mode = input.mode ?? "iterate"
 
-    if (record.locked && mode !== "create") {
-      throw new Error(`Artifact ${id} is locked and cannot be written`)
+    if (record.finalized && mode !== "create") {
+      throw new Error(`Artifact ${id} is finalized and cannot be written`)
     }
 
     if (mode === "create") {
@@ -231,8 +231,8 @@ export class FilesystemArtifactAdapter implements ArtifactAdapter {
   ): Promise<ArtifactRecord> {
     const record = await this.loadMeta(id)
 
-    if (record.locked) {
-      throw new Error(`Artifact ${id} is locked and cannot be edited`)
+    if (record.finalized) {
+      throw new Error(`Artifact ${id} is finalized and cannot be edited`)
     }
 
     const body = await this.read(id)
@@ -297,7 +297,7 @@ export class FilesystemArtifactAdapter implements ArtifactAdapter {
           type: record.type,
           title: record.title,
           version: record.version,
-          locked: record.locked,
+          finalized: record.finalized,
           tags: record.tags,
           updated_at: record.updated_at,
         })
@@ -318,20 +318,20 @@ export class FilesystemArtifactAdapter implements ArtifactAdapter {
   }
 
   // -------------------------------------------------------------------------
-  // lock
+  // finalize
   // -------------------------------------------------------------------------
 
-  async lock(id: ArtifactId): Promise<ArtifactRecord> {
+  async finalize(id: ArtifactId): Promise<ArtifactRecord> {
     const record = await this.loadMeta(id)
 
-    if (record.locked) {
-      // Idempotent — already locked
+    if (record.finalized) {
+      // Idempotent — already finalized
       return record
     }
 
     const updated: ArtifactRecord = {
       ...record,
-      locked: true,
+      finalized: true,
       updated_at: new Date().toISOString(),
     }
     await this.writeMeta(updated)
@@ -376,7 +376,7 @@ function matchesQuery(
 ): boolean {
   if (query === undefined) return true
   if (query.type !== undefined && record.type !== query.type) return false
-  if (query.locked !== undefined && record.locked !== query.locked) return false
+  if (query.finalized !== undefined && record.finalized !== query.finalized) return false
   if (query.tags !== undefined && query.tags.length > 0) {
     const hasAny = query.tags.some((t) => record.tags.includes(t))
     if (!hasAny) return false

--- a/src/cli/commands/artifact.test.ts
+++ b/src/cli/commands/artifact.test.ts
@@ -9,7 +9,7 @@ import {
   artifactEditCommand,
   artifactInspectCommand,
   artifactListCommand,
-  artifactLockCommand,
+  artifactFinalizeCommand,
 } from "./artifact.js"
 import { FilesystemArtifactAdapter } from "../../artifact/filesystem.js"
 import { FilesystemAdapter } from "../../memory/filesystem.js"
@@ -93,7 +93,7 @@ describe("artifact CLI commands", () => {
       expect(record.type).toBe("brief")
       expect(record.title).toBe("Q2 Launch Brief")
       expect(record.version).toBe(1)
-      expect(record.locked).toBe(false)
+      expect(record.finalized).toBe(false)
       expect(record.tags).toEqual(["q2", "launch"])
       expect(record.id).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/)
       expect(result.hook).toBeUndefined()
@@ -324,54 +324,54 @@ describe("artifact CLI commands", () => {
   })
 
   // -------------------------------------------------------------------------
-  // artifact lock
+  // artifact finalize
   // -------------------------------------------------------------------------
 
-  describe("artifact lock", () => {
-    it("locks the artifact", async () => {
+  describe("artifact finalize", () => {
+    it("finalizes the artifact", async () => {
       const adapter = new FilesystemArtifactAdapter(tmpDir)
       const record = await adapter.create({ type: "doc", title: "T", body: "body" })
 
       const out = await captureStdout(() =>
-        artifactLockCommand(ctx, [record.id], {}),
+        artifactFinalizeCommand(ctx, [record.id], {}),
       )
       const result = JSON.parse(out)
-      expect(result.artifact.locked).toBe(true)
+      expect(result.artifact.finalized).toBe(true)
     })
 
-    it("persists locked state", async () => {
+    it("persists finalized state", async () => {
       const adapter = new FilesystemArtifactAdapter(tmpDir)
       const record = await adapter.create({ type: "doc", title: "T", body: "body" })
-      await artifactLockCommand(ctx, [record.id], {})
+      await artifactFinalizeCommand(ctx, [record.id], {})
 
       const meta = await adapter.inspect(record.id)
-      expect(meta.locked).toBe(true)
+      expect(meta.finalized).toBe(true)
     })
 
     it("throws on missing id", async () => {
-      await expect(artifactLockCommand(ctx, [], {})).rejects.toThrow(/usage/i)
+      await expect(artifactFinalizeCommand(ctx, [], {})).rejects.toThrow(/usage/i)
     })
 
-    it("fires artifact.locked hook when script exists", async () => {
+    it("fires artifact.finalized hook when script exists", async () => {
       const adapter = new FilesystemArtifactAdapter(tmpDir)
       const record = await adapter.create({ type: "doc", title: "T", body: "body" })
 
       const hooksDir = join(tmpDir, ".spores", "hooks")
       await mkdir(hooksDir, { recursive: true })
-      const hookScript = join(hooksDir, "artifact.locked")
+      const hookScript = join(hooksDir, "artifact.finalized")
       await writeFile(
         hookScript,
-        `#!/usr/bin/env sh\necho "locked: $SPORES_ARTIFACT_ID v$SPORES_ARTIFACT_FINAL_VERSION"`,
+        `#!/usr/bin/env sh\necho "finalized: $SPORES_ARTIFACT_ID v$SPORES_ARTIFACT_FINAL_VERSION"`,
       )
       await chmod(hookScript, 0o755)
 
       const out = await captureStdout(() =>
-        artifactLockCommand(ctx, [record.id], {}),
+        artifactFinalizeCommand(ctx, [record.id], {}),
       )
       const result = JSON.parse(out)
       expect(result.hook).toBeDefined()
       expect(result.hook.ran).toBe(true)
-      expect(result.hook.stdout).toContain("locked:")
+      expect(result.hook.stdout).toContain("finalized:")
     })
   })
 })

--- a/src/cli/commands/artifact.ts
+++ b/src/cli/commands/artifact.ts
@@ -2,7 +2,7 @@ import type {
   ArtifactCreatedOutput,
   ArtifactWrittenOutput,
   ArtifactEditedOutput,
-  ArtifactLockedOutput,
+  ArtifactFinalizedOutput,
   ArtifactInspectedOutput,
   ArtifactRef,
   HookInvocation,
@@ -15,7 +15,7 @@ import {
   formatArtifactCreated,
   formatArtifactWritten,
   formatArtifactEdited,
-  formatArtifactLocked,
+  formatArtifactFinalized,
   formatArtifactInspected,
   formatArtifactList,
 } from "../format.js"
@@ -238,31 +238,35 @@ export const artifactListCommand: Command = async (ctx, _args, flags) => {
     typeof flags["tags"] === "string"
       ? flags["tags"].split(",").map((s) => s.trim())
       : undefined
-  const lockedFlag = flags["locked"]
-  const locked =
-    lockedFlag === true ? true : lockedFlag === "false" ? false : undefined
+  const finalizedFlag = flags["finalized"]
+  const finalized =
+    finalizedFlag === true
+      ? true
+      : finalizedFlag === "false"
+        ? false
+        : undefined
 
   const adapter = new FilesystemArtifactAdapter(ctx.baseDir)
-  const refs: ArtifactRef[] = await adapter.list({ type, tags, locked })
+  const refs: ArtifactRef[] = await adapter.list({ type, tags, finalized })
 
   output(ctx, refs, formatArtifactList)
 }
 
 // ---------------------------------------------------------------------------
-// artifact lock
+// artifact finalize
 // ---------------------------------------------------------------------------
 
-export const artifactLockCommand: Command = async (ctx, args, _flags) => {
+export const artifactFinalizeCommand: Command = async (ctx, args, _flags) => {
   const id = args[0]
   if (id === undefined) {
-    throw new Error("Usage: spores artifact lock <id>")
+    throw new Error("Usage: spores artifact finalize <id>")
   }
 
   const adapter = new FilesystemArtifactAdapter(ctx.baseDir)
-  const record = await adapter.lock(id)
+  const record = await adapter.finalize(id)
 
   const hook = await fireHook(
-    "artifact.locked",
+    "artifact.finalized",
     {
       SPORES_ARTIFACT_ID: record.id,
       SPORES_ARTIFACT_FINAL_VERSION: String(record.version),
@@ -270,10 +274,10 @@ export const artifactLockCommand: Command = async (ctx, args, _flags) => {
     ctx.baseDir,
   )
 
-  const result: ArtifactLockedOutput = {
+  const result: ArtifactFinalizedOutput = {
     artifact: record,
     hook: hook.ran ? hook : undefined,
   }
-  output(ctx, result, formatArtifactLocked)
-  emitHookWarning("artifact.locked", hook)
+  output(ctx, result, formatArtifactFinalized)
+  emitHookWarning("artifact.finalized", hook)
 }

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -33,7 +33,7 @@ import type {
   ArtifactCreatedOutput,
   ArtifactWrittenOutput,
   ArtifactEditedOutput,
-  ArtifactLockedOutput,
+  ArtifactFinalizedOutput,
   ArtifactInspectedOutput,
   CapabilityDef,
 } from "../types.js"
@@ -440,10 +440,10 @@ export function formatWake(result: WakeOutput): string {
 
 export function formatArtifactRecord(r: ArtifactRecord): string {
   const tags = r.tags.length > 0 ? ` [${r.tags.join(", ")}]` : ""
-  const locked = r.locked ? " (locked)" : ""
+  const finalized = r.finalized ? " (finalized)" : ""
   const derived = r.derived_from !== undefined ? `\n  derived_from: ${r.derived_from}` : ""
   return [
-    `${r.id}${locked}`,
+    `${r.id}${finalized}`,
     `  type:    ${r.type}`,
     `  title:   ${r.title}${tags}`,
     `  version: ${r.version}`,
@@ -453,12 +453,12 @@ export function formatArtifactRecord(r: ArtifactRecord): string {
 
 export function formatArtifactMetadata(m: ArtifactMetadata): string {
   const tags = m.tags.length > 0 ? ` [${m.tags.join(", ")}]` : ""
-  const locked = m.locked ? " (locked)" : ""
+  const finalized = m.finalized ? " (finalized)" : ""
   const size =
     m.size_bytes !== undefined ? `\n  size:    ${m.size_bytes} bytes` : ""
   const derived = m.derived_from !== undefined ? `\n  derived_from: ${m.derived_from}` : ""
   return [
-    `${m.id}${locked}`,
+    `${m.id}${finalized}`,
     `  type:     ${m.type}`,
     `  title:    ${m.title}${tags}`,
     `  version:  ${m.version}`,
@@ -501,9 +501,9 @@ export function formatArtifactEdited(result: ArtifactEditedOutput): string {
   return parts.join("\n")
 }
 
-/** Human formatter for `artifact lock`. */
-export function formatArtifactLocked(result: ArtifactLockedOutput): string {
-  const parts = [`Artifact locked:\n${formatArtifactRecord(result.artifact)}`]
+/** Human formatter for `artifact finalize`. */
+export function formatArtifactFinalized(result: ArtifactFinalizedOutput): string {
+  const parts = [`Artifact finalized:\n${formatArtifactRecord(result.artifact)}`]
   const hook = result.hook
   if (hook !== undefined && hook.ran && hook.stdout.trim().length > 0) {
     parts.push("\n---\n")
@@ -521,13 +521,13 @@ export function formatArtifactInspected(result: ArtifactInspectedOutput): string
 export function formatArtifactList(refs: ArtifactRef[]): string {
   if (refs.length === 0) return "No artifacts found."
   return table(
-    ["ID", "TYPE", "TITLE", "VER", "LOCKED"],
+    ["ID", "TYPE", "TITLE", "VER", "FINALIZED"],
     refs.map((r) => [
       r.id,
       r.type,
       r.title,
       String(r.version),
-      r.locked ? "yes" : "no",
+      r.finalized ? "yes" : "no",
     ]),
   )
 }

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -52,7 +52,7 @@ import {
   artifactEditCommand,
   artifactInspectCommand,
   artifactListCommand,
-  artifactLockCommand,
+  artifactFinalizeCommand,
 } from "./commands/artifact.js"
 import {
   capabilityListCommand,
@@ -132,7 +132,7 @@ const commands: Record<string, Command> = {
   "artifact edit": artifactEditCommand,
   "artifact inspect": artifactInspectCommand,
   "artifact list": artifactListCommand,
-  "artifact lock": artifactLockCommand,
+  "artifact finalize": artifactFinalizeCommand,
   "capability list": capabilityListCommand,
   "capability show": capabilityShowCommand,
   "capability validate": capabilityValidateCommand,
@@ -184,7 +184,7 @@ Commands:
   artifact edit <id>                  Edit artifact body (--old / --new)
   artifact inspect <id>               Show artifact metadata
   artifact list                       List artifacts (filter with flags)
-  artifact lock <id>                  Lock an artifact (append-only)
+  artifact finalize <id>              Finalize an artifact (read-only)
 
   capability list                     List available capabilities
   capability show <name>              Show capability declaration details

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ export type {
   ArtifactCreatedOutput,
   ArtifactWrittenOutput,
   ArtifactEditedOutput,
-  ArtifactLockedOutput,
+  ArtifactFinalizedOutput,
   ArtifactInspectedOutput,
   CapabilityEffect,
   PolicyError,

--- a/src/lifecycle-events.test.ts
+++ b/src/lifecycle-events.test.ts
@@ -10,7 +10,7 @@ describe("lifecycle event vocabulary", () => {
     const expected: readonly LifecycleEventName[] = [
       "artifact.created",
       "artifact.written",
-      "artifact.locked",
+      "artifact.finalized",
       "persona.activated",
       "workflow.transitioned",
       "memory.remembered",

--- a/src/types.ts
+++ b/src/types.ts
@@ -383,7 +383,7 @@ export type LifecyclePrimitive =
 export type LifecycleEventName =
   | "artifact.created"
   | "artifact.written"
-  | "artifact.locked"
+  | "artifact.finalized"
   | "persona.activated"
   | "workflow.transitioned"
   | "memory.remembered"
@@ -399,7 +399,7 @@ export type LifecycleEventName =
 export const LIFECYCLE_EVENTS: readonly LifecycleEventName[] = [
   "artifact.created",
   "artifact.written",
-  "artifact.locked",
+  "artifact.finalized",
   "persona.activated",
   "workflow.transitioned",
   "memory.remembered",
@@ -416,7 +416,7 @@ export const LIFECYCLE_EVENTS: readonly LifecycleEventName[] = [
 export const LIFECYCLE_EVENT_PRIMITIVES: Readonly<Record<LifecycleEventName, LifecyclePrimitive>> = {
   "artifact.created": "artifact",
   "artifact.written": "artifact",
-  "artifact.locked": "artifact",
+  "artifact.finalized": "artifact",
   "persona.activated": "persona",
   "workflow.transitioned": "workflow",
   "memory.remembered": "memory",
@@ -465,12 +465,12 @@ export type LifecycleEvent<TName extends LifecycleEventName = LifecycleEventName
 // Artifact types
 //
 // An Artifact is a named, versioned piece of content produced by an agent
-// turn — addressable, persistable, lockable, and hookable. It is the
+// turn — addressable, persistable, finalizable, and hookable. It is the
 // standalone primitive that workflow node outputs (Transition.artifact) point
 // at once they have been persisted.
 //
-// Lifecycle: created → written (iterate | replace) → locked (append-only).
-// Deletion is intentionally absent from the MVP; locked artifacts are
+// Lifecycle: created → written (iterate | replace) → finalized (read-only).
+// Deletion is intentionally absent from the MVP; finalized artifacts are
 // append-only history. Archive/drop can come later once use signals it.
 // ---------------------------------------------------------------------------
 
@@ -487,7 +487,7 @@ export type ArtifactRecord = {
   title: string
   body_ref: string           // adapter-defined reference (FS path, blob key, etc.)
   version: number
-  locked: boolean
+  finalized: boolean
   tags: string[]
   created_at: string         // ISO 8601
   updated_at: string         // ISO 8601
@@ -509,7 +509,7 @@ export type ArtifactRef = {
   type: string
   title: string
   version: number
-  locked: boolean
+  finalized: boolean
   tags: string[]
   updated_at: string
 }
@@ -518,7 +518,7 @@ export type ArtifactRef = {
 export type ArtifactQuery = {
   type?: string | undefined
   tags?: string[] | undefined
-  locked?: boolean | undefined
+  finalized?: boolean | undefined
 }
 
 /**
@@ -897,10 +897,10 @@ export type ArtifactEditedOutput = {
 }
 
 /**
- * Output of `artifact lock` — the locked record plus any `artifact.locked`
+ * Output of `artifact finalize` — the finalized record plus any `artifact.finalized`
  * hook that fired.
  */
-export type ArtifactLockedOutput = {
+export type ArtifactFinalizedOutput = {
   artifact: ArtifactRecord
   hook?: HookInvocation | undefined
 }


### PR DESCRIPTION
## Summary
- rename artifact lock/locked vocabulary to finalize/finalized across API, CLI, docs, and lifecycle events
- replace the persisted ArtifactRecord field with finalized
- update artifact hooks and lifecycle vocabulary to artifact.finalized

Closes #91

## Tests
- bun test src/artifact/filesystem.test.ts
- bun test src/cli/commands/artifact.test.ts
- bun test src/lifecycle-events.test.ts
- bun test
- bun run typecheck