### PR TITLE
fix(ci): resolve Node 20 deprecation warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     name: test + typecheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -28,7 +28,7 @@ jobs:
       - name: Build (tsc → dist/)
         run: bun run build
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "22"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
       # against the trusted publisher registered on npmjs.com.
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -34,7 +34,7 @@ jobs:
       - name: Build (tsc → dist/)
         run: bun run build
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
Closes #97

GitHub Actions will force Node 20 actions to Node 24 by default starting June 16, 2026, and remove Node 20 from the runner on September 16, 2026.

Updates both `actions/checkout` and `actions/setup-node` from v4 to v5, which use the Node 24 runtime and eliminate the deprecation annotation.

No change to release semantics — Trusted Publishing, build, and test steps remain identical.