### PR TITLE
docs: make second-brain example runnable with local runtime

### DIFF
--- a/.agentic/config.toml
+++ b/.agentic/config.toml
@@ -11,3 +11,9 @@ dream_depth = "3"
 [workflow]
 graphs_dir = ".agentic/workflows"
 runs_dir = ".agentic/runs"
+
+[runtime]
+default = "local"
+
+[runtime.local]
+package = "@tnezdev/agentic-runtime-local"

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,12 @@
     "": {
       "name": "agentic-workspace",
     },
+    "examples/second-brain": {
+      "name": "second-brain-example",
+      "devDependencies": {
+        "@tnezdev/agentic-runtime-local": "workspace:*",
+      },
+    },
     "packages/agentic": {
       "name": "@tnezdev/agentic",
       "version": "0.5.0",
@@ -43,6 +49,8 @@
     "@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
 
     "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+
+    "second-brain-example": ["second-brain-example@workspace:examples/second-brain"],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 

--- a/examples/second-brain/.agentic/artifacts/01KTC500000000000000000010/meta.json
+++ b/examples/second-brain/.agentic/artifacts/01KTC500000000000000000010/meta.json
@@ -1,0 +1,16 @@
+{
+  "id": "01KTC500000000000000000010",
+  "type": "research-brief",
+  "title": "Visible Switch Options Research Seed",
+  "body_ref": "01KTC500000000000000000010/v1.md",
+  "version": 1,
+  "finalized": true,
+  "tags": [
+    "second-brain",
+    "research",
+    "example",
+    "para:resource/agentic-examples"
+  ],
+  "created_at": "2026-06-05T16:00:00.000Z",
+  "updated_at": "2026-06-05T16:00:00.000Z"
+}

--- a/examples/second-brain/.agentic/artifacts/01KTC500000000000000000010/v1.md
+++ b/examples/second-brain/.agentic/artifacts/01KTC500000000000000000010/v1.md
@@ -1,0 +1,35 @@
+# Visible Switch Options Research Seed
+
+## Question
+
+What physical or software-visible switch options could support a private second-brain input workflow?
+
+## Why It Matters
+
+A second-brain system gets better when capture is low-friction and intentional. A visible switch can make mode changes explicit: capture, focus, do-not-disturb, or research intake.
+
+## Findings
+
+- The useful axis is not hardware versus software. It is whether the switch state is observable by the host runtime.
+- A good switch should expose state, not just fire an event. Agents need to know the current mode after restarts.
+- The example should not bake in a particular device. Agentic should model the research loop and durable output, while the host runtime owns device integration.
+
+## Tradeoffs
+
+- Hardware switches are tangible and reliable, but integration is host-specific.
+- Software toggles are portable and easier to demo, but less physically salient.
+- Calendar or focus-mode signals may already exist, but they blur user intent with ambient context.
+
+## Recommendation
+
+For a public Agentic example, keep the switch question as seed content only. Demonstrate the reusable second-brain research loop, not a device-specific integration.
+
+## Sources Consulted
+
+- Example seed only. Replace with real source notes during a live research pass.
+
+## Follow-Up Questions
+
+- Which host runtime will observe switch state?
+- Does the user need momentary events, durable state, or both?
+- Should switch state become memory, dispatch context, or runtime-local state?

--- a/examples/second-brain/.agentic/config.toml
+++ b/examples/second-brain/.agentic/config.toml
@@ -1,0 +1,18 @@
+# Agentic configuration for the second-brain example.
+
+adapter = "filesystem"
+
+[memory]
+dir = ".agentic/memory"
+default_tier = "L1"
+dream_depth = "3"
+
+[workflow]
+graphs_dir = ".agentic/workflows"
+runs_dir = ".agentic/runs"
+
+[runtime]
+default = "local"
+
+[runtime.local]
+package = "@tnezdev/agentic-runtime-local"

--- a/examples/second-brain/.agentic/personas/researcher.md
+++ b/examples/second-brain/.agentic/personas/researcher.md
@@ -1,0 +1,44 @@
+---
+name: researcher
+description: Activate when turning an open question into a concise second-brain research brief
+memory_tags: [second-brain, research]
+skills: [research-brief, project-kickoff]
+task_filter:
+  tags: [research]
+  status: ready
+workflow: research-loop
+effort: medium
+reasoning: high
+---
+
+# Second-Brain Researcher
+
+You are maintaining a second-brain research workspace from `{{cwd}}` on `{{hostname}}`.
+The current time is `{{timestamp}}`.
+
+## Operating Principles
+
+- Start by restating the question and the decision it supports.
+- Prefer durable findings over exhaustive notes.
+- Separate evidence, interpretation, and recommendation.
+- Preserve uncertainty. If a source is weak, say so.
+- Write the output as an artifact that can be read later without the transcript.
+
+## Before Research
+
+1. Check `task next` for the active research question.
+2. Run the `research-brief` skill for the work procedure.
+3. If user memory is configured, recall relevant context tagged `second-brain` and `research`.
+4. Use the `research-loop` workflow when the question spans more than one pass.
+
+## Output Shape
+
+Produce a brief with:
+
+- Question
+- Why it matters
+- Findings
+- Tradeoffs
+- Recommendation
+- Sources consulted
+- Follow-up questions

--- a/examples/second-brain/.agentic/runtime/local/runtime.json
+++ b/examples/second-brain/.agentic/runtime/local/runtime.json
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "runtime": "local",
+  "package_name": "@tnezdev/agentic-runtime-local",
+  "targets_dir": "targets"
+}

--- a/examples/second-brain/.agentic/skills/project-kickoff/skill.md
+++ b/examples/second-brain/.agentic/skills/project-kickoff/skill.md
@@ -1,0 +1,76 @@
+---
+name: project-kickoff
+description: Activate when an agent needs to turn a project idea into a scoped PARA project without guessing the user's intent
+tags: [second-brain, project, para, intake]
+---
+
+# Project Kickoff
+
+Use this procedure when the user wants to start or shape a project in a second-brain workspace.
+
+## Principles
+
+- Organize by actionability. A project exists to support a concrete outcome, not to classify information by broad subject.
+- A project is a short-term effort with a goal. If it has no finish line, it is probably an area, resource, or habit instead.
+- Do not draft a project plan from a title alone. First gather enough intent to avoid creating plausible but wrong tasks.
+- Keep the first plan lightweight. The goal is clarity and movement, not a perfect system.
+- End with the next essential step, not an exhaustive backlog.
+
+## Intake First
+
+Before creating a `project-plan` artifact, ask concise questions. Prefer 3-5 questions at a time.
+
+Ask about:
+
+- Outcome: What should be true when this project is done?
+- Motivation: Why does this matter now?
+- Scope: What is in bounds, and what is explicitly out of bounds for the first pass?
+- Constraints: Are there deadlines, tools, people, budgets, or standards to respect?
+- Current state: What already exists, and where is the messy input coming from?
+- Success criteria: How will we know this worked?
+- First useful action: What would create momentum without overbuilding?
+
+If the user already gave enough context, summarize your assumptions and ask for confirmation before creating durable artifacts. If the user explicitly asks for a speculative draft, label assumptions clearly.
+
+## PARA Placement
+
+Choose a concrete project bucket tag:
+
+```text
+para:project/<slug>
+```
+
+If the work is ongoing with no completion point, suggest an area tag instead:
+
+```text
+para:area/<slug>
+```
+
+If it is reference material without an active outcome, suggest a resource tag:
+
+```text
+para:resource/<slug>
+```
+
+## Project Plan Artifact
+
+After intake, write a `project-plan` artifact with:
+
+- Outcome
+- Why It Matters
+- Success Criteria
+- Scope
+- Constraints
+- Current State
+- PARA Bucket
+- Milestones or Intermediate Packets
+- Risks
+- Current Next Actions
+
+Every project plan must include a `para:project/<slug>` tag unless the intake reveals it is not actually a project.
+
+## Next Actions
+
+Next actions should respect dependencies. Do not choose a later action if an earlier structure does not exist yet.
+
+For example, if the project is to create a reading queue, do not pick the first reading item until the queue surface, fields, and statuses exist. The better next action is to define the queue shape from the user's requirements.

--- a/examples/second-brain/.agentic/skills/research-brief/skill.md
+++ b/examples/second-brain/.agentic/skills/research-brief/skill.md
@@ -1,0 +1,50 @@
+---
+name: research-brief
+description: Activate when an agent needs to convert a research question into a cited second-brain brief
+tags: [second-brain, research, artifact]
+---
+
+# Research Brief
+
+Use this procedure when the task is to answer a research question for later reuse.
+
+## Procedure
+
+1. Restate the question in one sentence.
+2. Identify the decision or action the answer should support.
+3. Gather a small set of high-signal sources. Prefer primary sources, official docs, source code, standards, and direct measurements.
+4. Extract findings as claims with source references. Do not preserve raw browsing notes unless they are necessary evidence.
+5. Synthesize tradeoffs. Call out uncertainty and missing information.
+6. Write a brief artifact. Keep it readable without the transcript.
+7. Validate that the artifact has at least one PARA bucket tag.
+8. Finalize the artifact once taxonomy validation passes.
+9. Add follow-up tasks only for unresolved questions that affect a decision.
+
+## Artifact Contract
+
+Write a `research-brief` artifact with these sections:
+
+- `Question`
+- `Why It Matters`
+- `Findings`
+- `Tradeoffs`
+- `Recommendation`
+- `Sources Consulted`
+- `Follow-Up Questions`
+
+Every artifact must include at least one PARA bucket tag in this form:
+
+```text
+para:<bucket>/<slug>
+```
+
+Allowed buckets are `project`, `area`, `resource`, and `archive`. Choose the bucket that describes where the brief belongs in the user's second-brain system.
+
+Do not finalize the artifact until this tag is present. Finalization means the brief is durable output for this research pass, not that it can never be superseded.
+
+## Quality Bar
+
+- A reader can tell what changed in their understanding.
+- Recommendation follows from the evidence.
+- Sources are named clearly enough to revisit.
+- Unknowns are explicit instead of hidden in confident prose.

--- a/examples/second-brain/.agentic/tasks/01KTC500000000000000000001.json
+++ b/examples/second-brain/.agentic/tasks/01KTC500000000000000000001.json
@@ -1,0 +1,18 @@
+{
+  "id": "01KTC500000000000000000001",
+  "description": "Research visible switch options for a private second-brain input workflow",
+  "status": "ready",
+  "tags": [
+    "second-brain",
+    "research",
+    "example"
+  ],
+  "annotations": [
+    {
+      "text": "Seed task for the public example. Replace with a real recurring research question in your own workspace.",
+      "timestamp": "2026-06-05T16:00:00.000Z"
+    }
+  ],
+  "created_at": "2026-06-05T16:00:00.000Z",
+  "updated_at": "2026-06-05T16:00:00.000Z"
+}

--- a/examples/second-brain/.agentic/workflows/monthly-review.json
+++ b/examples/second-brain/.agentic/workflows/monthly-review.json
@@ -1,0 +1,69 @@
+{
+  "id": "monthly-review",
+  "name": "Monthly review",
+  "description": "Review project portfolio, areas, resources, and goals at monthly cadence.",
+  "version": "1.0",
+  "nodes": [
+    {
+      "id": "summarize-month",
+      "label": "Summarize month",
+      "description": "Summarize major outputs, decisions, changes, and unresolved tensions from the month.",
+      "artifact": {
+        "type": "monthly-summary",
+        "description": "Narrative summary of the month.",
+        "required": true,
+        "tags": ["second-brain", "review", "monthly"]
+      }
+    },
+    {
+      "id": "review-portfolio",
+      "label": "Review portfolio",
+      "description": "Review active projects and areas for alignment, overcommitment, and stale commitments.",
+      "artifact": {
+        "type": "portfolio-review",
+        "description": "Monthly project and area portfolio review.",
+        "required": true,
+        "tags": ["second-brain", "project", "area"]
+      }
+    },
+    {
+      "id": "promote-resources",
+      "label": "Promote resources",
+      "description": "Identify reusable notes, briefs, and references that should become resource bucket material.",
+      "artifact": {
+        "type": "resource-review",
+        "description": "Resources to promote, merge, prune, or revisit.",
+        "required": true,
+        "tags": ["second-brain", "resource"]
+      }
+    },
+    {
+      "id": "choose-month-focus",
+      "label": "Choose month focus",
+      "description": "Choose the next month's priorities, constraints, and explicit not-now list.",
+      "artifact": {
+        "type": "monthly-plan",
+        "description": "Next month focus and planning decisions.",
+        "required": true,
+        "tags": ["second-brain", "review", "plan"]
+      }
+    },
+    {
+      "id": "finalize-review",
+      "label": "Finalize review",
+      "description": "Finalize the monthly review artifact and update tasks or memories with durable decisions.",
+      "artifact": {
+        "type": "finalized-artifact-ref",
+        "description": "Reference to finalized monthly review and updates made.",
+        "required": true,
+        "tags": ["second-brain", "artifact", "memory", "tasks"]
+      }
+    }
+  ],
+  "edges": [
+    { "from": "summarize-month", "to": "review-portfolio" },
+    { "from": "review-portfolio", "to": "promote-resources" },
+    { "from": "promote-resources", "to": "choose-month-focus" },
+    { "from": "choose-month-focus", "to": "finalize-review" }
+  ]
+}

--- a/examples/second-brain/.agentic/workflows/process-inbox.json
+++ b/examples/second-brain/.agentic/workflows/process-inbox.json
@@ -1,0 +1,69 @@
+{
+  "id": "process-inbox",
+  "name": "Process inbox",
+  "description": "Turn uncategorized captures into tasks, memories, artifacts, or PARA bucket placements.",
+  "version": "1.0",
+  "nodes": [
+    {
+      "id": "collect-inbox",
+      "label": "Collect inbox",
+      "description": "Gather uncategorized notes, links, files, and reminders that need routing.",
+      "artifact": {
+        "type": "inbox-batch",
+        "description": "Batch of inbox items to process.",
+        "required": true,
+        "tags": ["second-brain", "inbox"]
+      }
+    },
+    {
+      "id": "triage-items",
+      "label": "Triage items",
+      "description": "For each item, decide delete, defer, delegate, task, memory, artifact, or reference.",
+      "artifact": {
+        "type": "inbox-triage",
+        "description": "Triage decision for each inbox item.",
+        "required": true,
+        "tags": ["second-brain", "inbox", "triage"]
+      }
+    },
+    {
+      "id": "assign-buckets",
+      "label": "Assign buckets",
+      "description": "Assign retained items to concrete PARA buckets using para:<bucket>/<slug> tags.",
+      "artifact": {
+        "type": "taxonomy-validation",
+        "description": "PARA bucket assignment for retained inbox items.",
+        "required": true,
+        "tags": ["second-brain", "taxonomy"]
+      }
+    },
+    {
+      "id": "create-outputs",
+      "label": "Create outputs",
+      "description": "Create tasks, memories, or artifacts for retained items; discard or archive the rest.",
+      "artifact": {
+        "type": "inbox-output-summary",
+        "description": "Created tasks, memories, artifacts, and discarded items.",
+        "required": true,
+        "tags": ["second-brain", "tasks", "memory", "artifact"]
+      }
+    },
+    {
+      "id": "close-batch",
+      "label": "Close batch",
+      "description": "Confirm the inbox batch is empty or only contains intentionally deferred items.",
+      "artifact": {
+        "type": "inbox-closeout",
+        "description": "Closeout note for the processed inbox batch.",
+        "required": true,
+        "tags": ["second-brain", "inbox"]
+      }
+    }
+  ],
+  "edges": [
+    { "from": "collect-inbox", "to": "triage-items" },
+    { "from": "triage-items", "to": "assign-buckets" },
+    { "from": "assign-buckets", "to": "create-outputs" },
+    { "from": "create-outputs", "to": "close-batch" }
+  ]
+}

--- a/examples/second-brain/.agentic/workflows/project-archive.json
+++ b/examples/second-brain/.agentic/workflows/project-archive.json
@@ -1,0 +1,69 @@
+{
+  "id": "project-archive",
+  "name": "Project archive",
+  "description": "Close a PARA project, preserve lessons, and move reusable material to the right long-term bucket.",
+  "version": "1.0",
+  "nodes": [
+    {
+      "id": "review-outcome",
+      "label": "Review outcome",
+      "description": "Compare the project outcome against the original success criteria and current reality.",
+      "artifact": {
+        "type": "project-retrospective",
+        "description": "Outcome review, what shipped, what changed, and what did not happen.",
+        "required": true,
+        "tags": ["second-brain", "project", "review"]
+      }
+    },
+    {
+      "id": "extract-lessons",
+      "label": "Extract lessons",
+      "description": "Capture durable lessons, reusable patterns, and warnings as memories or artifacts.",
+      "artifact": {
+        "type": "lessons-learned",
+        "description": "Reusable lessons from the project and suggested memory updates.",
+        "required": true,
+        "tags": ["second-brain", "memory"]
+      }
+    },
+    {
+      "id": "reclassify-material",
+      "label": "Reclassify material",
+      "description": "Move or retag durable outputs into area, resource, or archive buckets.",
+      "artifact": {
+        "type": "taxonomy-validation",
+        "description": "PARA reclassification plan for project artifacts and references.",
+        "required": true,
+        "tags": ["second-brain", "taxonomy"]
+      }
+    },
+    {
+      "id": "close-loops",
+      "label": "Close loops",
+      "description": "Mark completed tasks done, cancel obsolete tasks, and create follow-up tasks only for live commitments.",
+      "artifact": {
+        "type": "next-actions",
+        "description": "Task closure and remaining follow-up actions.",
+        "required": true,
+        "tags": ["second-brain", "tasks"]
+      }
+    },
+    {
+      "id": "finalize-archive-note",
+      "label": "Finalize archive note",
+      "description": "Write and finalize the archive note with a para:archive/<slug> or successor bucket tag.",
+      "artifact": {
+        "type": "archive-note",
+        "description": "Final project archive note suitable for future retrieval.",
+        "required": true,
+        "tags": ["second-brain", "archive"]
+      }
+    }
+  ],
+  "edges": [
+    { "from": "review-outcome", "to": "extract-lessons" },
+    { "from": "extract-lessons", "to": "reclassify-material" },
+    { "from": "reclassify-material", "to": "close-loops" },
+    { "from": "close-loops", "to": "finalize-archive-note" }
+  ]
+}

--- a/examples/second-brain/.agentic/workflows/project-kickoff.json
+++ b/examples/second-brain/.agentic/workflows/project-kickoff.json
@@ -1,0 +1,82 @@
+{
+  "id": "project-kickoff",
+  "name": "Project kickoff",
+  "description": "Turn a project idea into a scoped PARA project with next actions and success criteria.",
+  "version": "1.0",
+  "nodes": [
+    {
+      "id": "intake-questions",
+      "label": "Ask kickoff questions",
+      "description": "Ask the user enough questions to understand the project outcome, motivation, constraints, success criteria, and first useful next action. Do not draft the project plan from assumptions unless the user explicitly asks for a speculative draft.",
+      "type": "manual",
+      "artifact": {
+        "type": "project-intake",
+        "description": "User-provided answers or explicitly labeled assumptions from the kickoff interview.",
+        "required": true,
+        "tags": ["second-brain", "project", "intake"]
+      }
+    },
+    {
+      "id": "define-outcome",
+      "label": "Define outcome",
+      "description": "State the desired outcome, why it matters, and what done looks like using the kickoff intake answers as source material.",
+      "artifact": {
+        "type": "project-outcome",
+        "description": "Project outcome, success criteria, and decision context.",
+        "required": true,
+        "tags": ["second-brain", "project"]
+      }
+    },
+    {
+      "id": "choose-para-bucket",
+      "label": "Choose PARA bucket",
+      "description": "Assign the project to a concrete PARA project tag in the form para:project/<slug>.",
+      "artifact": {
+        "type": "taxonomy-validation",
+        "description": "Selected PARA project tag and rationale.",
+        "required": true,
+        "tags": ["second-brain", "taxonomy"]
+      }
+    },
+    {
+      "id": "map-resources",
+      "label": "Map resources",
+      "description": "Identify related areas, resources, constraints, stakeholders, and reference material.",
+      "artifact": {
+        "type": "project-context",
+        "description": "Context map for the project: related areas/resources, constraints, and references.",
+        "required": true,
+        "tags": ["second-brain", "project", "resources"]
+      }
+    },
+    {
+      "id": "create-project-plan",
+      "label": "Create project plan",
+      "description": "Write the project plan artifact with scope, milestones, risks, and next actions.",
+      "artifact": {
+        "type": "project-plan",
+        "description": "Durable project plan artifact tagged with para:project/<slug>.",
+        "required": true,
+        "tags": ["second-brain", "project", "plan"]
+      }
+    },
+    {
+      "id": "seed-next-actions",
+      "label": "Seed next actions",
+      "description": "Create or update tasks for the first concrete next actions.",
+      "artifact": {
+        "type": "next-actions",
+        "description": "Initial task list or task updates for the project.",
+        "required": true,
+        "tags": ["second-brain", "tasks"]
+      }
+    }
+  ],
+  "edges": [
+    { "from": "intake-questions", "to": "define-outcome" },
+    { "from": "define-outcome", "to": "choose-para-bucket" },
+    { "from": "choose-para-bucket", "to": "map-resources" },
+    { "from": "map-resources", "to": "create-project-plan" },
+    { "from": "create-project-plan", "to": "seed-next-actions" }
+  ]
+}

--- a/examples/second-brain/.agentic/workflows/research-loop.json
+++ b/examples/second-brain/.agentic/workflows/research-loop.json
@@ -1,0 +1,81 @@
+{
+  "id": "research-loop",
+  "name": "Second-brain research loop",
+  "description": "Turn an open question into a durable research brief and explicit follow-up tasks.",
+  "version": "1.0",
+  "nodes": [
+    {
+      "id": "frame-question",
+      "label": "Frame question",
+      "description": "Restate the question, identify the decision it supports, and define what a useful answer must contain.",
+      "artifact": {
+        "type": "research-frame",
+        "description": "Question framing notes: decision, scope, constraints, and success criteria.",
+        "required": true,
+        "tags": ["second-brain", "research"]
+      }
+    },
+    {
+      "id": "gather-sources",
+      "label": "Gather sources",
+      "description": "Collect a small set of high-signal sources and record why each source is credible or limited.",
+      "artifact": {
+        "type": "source-notes",
+        "description": "Source list with claims, links or locators, and quality notes.",
+        "required": true,
+        "tags": ["second-brain", "research", "sources"]
+      }
+    },
+    {
+      "id": "write-brief",
+      "label": "Write brief",
+      "description": "Synthesize findings, tradeoffs, recommendation, and follow-up questions into a durable artifact.",
+      "artifact": {
+        "type": "research-brief",
+        "description": "Final research brief suitable for future recall.",
+        "required": true,
+        "tags": ["second-brain", "research", "brief"]
+      }
+    },
+    {
+      "id": "validate-taxonomy",
+      "label": "Validate taxonomy",
+      "description": "Inspect the research-brief artifact metadata and confirm it includes at least one valid PARA bucket tag in the form para:<bucket>/<slug> before finalization.",
+      "artifact": {
+        "type": "taxonomy-validation",
+        "description": "Validation note naming the artifact id and the PARA tag that places it in the user's second-brain system.",
+        "required": true,
+        "tags": ["second-brain", "taxonomy"]
+      }
+    },
+    {
+      "id": "finalize-brief",
+      "label": "Finalize brief",
+      "description": "Finalize the research-brief artifact after taxonomy validation passes so it becomes durable output for this research pass.",
+      "artifact": {
+        "type": "finalized-artifact-ref",
+        "description": "Reference to the finalized research-brief artifact.",
+        "required": true,
+        "tags": ["second-brain", "research", "artifact"]
+      }
+    },
+    {
+      "id": "decide-next-actions",
+      "label": "Decide next actions",
+      "description": "Mark the task done if the brief supports the decision, or add specific follow-up tasks for remaining blockers.",
+      "artifact": {
+        "type": "next-actions",
+        "description": "Task updates or follow-up questions derived from the brief.",
+        "required": false,
+        "tags": ["second-brain", "tasks"]
+      }
+    }
+  ],
+  "edges": [
+    { "from": "frame-question", "to": "gather-sources" },
+    { "from": "gather-sources", "to": "write-brief" },
+    { "from": "write-brief", "to": "validate-taxonomy" },
+    { "from": "validate-taxonomy", "to": "finalize-brief" },
+    { "from": "finalize-brief", "to": "decide-next-actions" }
+  ]
+}

--- a/examples/second-brain/.agentic/workflows/weekly-review.json
+++ b/examples/second-brain/.agentic/workflows/weekly-review.json
@@ -1,0 +1,69 @@
+{
+  "id": "weekly-review",
+  "name": "Weekly review",
+  "description": "Review active commitments, recent outputs, and next-week focus across the second-brain workspace.",
+  "version": "1.0",
+  "nodes": [
+    {
+      "id": "collect-inputs",
+      "label": "Collect inputs",
+      "description": "Gather open tasks, recent artifacts, calendar/context notes, and inbox items relevant to the week.",
+      "artifact": {
+        "type": "review-inputs",
+        "description": "Input summary for the weekly review.",
+        "required": true,
+        "tags": ["second-brain", "review", "weekly"]
+      }
+    },
+    {
+      "id": "review-projects",
+      "label": "Review projects",
+      "description": "Scan active project buckets for stuck work, missing next actions, and completed outcomes.",
+      "artifact": {
+        "type": "project-review",
+        "description": "Project-by-project weekly review notes.",
+        "required": true,
+        "tags": ["second-brain", "project", "weekly"]
+      }
+    },
+    {
+      "id": "review-areas",
+      "label": "Review areas",
+      "description": "Check active areas for maintenance issues, recurring obligations, and ignored standards.",
+      "artifact": {
+        "type": "area-review",
+        "description": "Area maintenance review and risks.",
+        "required": true,
+        "tags": ["second-brain", "area", "weekly"]
+      }
+    },
+    {
+      "id": "choose-focus",
+      "label": "Choose focus",
+      "description": "Pick the next week's priority focus and name what will intentionally not be pursued.",
+      "artifact": {
+        "type": "weekly-plan",
+        "description": "Weekly focus, tradeoffs, and next actions.",
+        "required": true,
+        "tags": ["second-brain", "review", "plan"]
+      }
+    },
+    {
+      "id": "finalize-review",
+      "label": "Finalize review",
+      "description": "Finalize the weekly review artifact with a valid PARA tag and update tasks.",
+      "artifact": {
+        "type": "finalized-artifact-ref",
+        "description": "Reference to finalized weekly review and task updates.",
+        "required": true,
+        "tags": ["second-brain", "artifact", "tasks"]
+      }
+    }
+  ],
+  "edges": [
+    { "from": "collect-inputs", "to": "review-projects" },
+    { "from": "review-projects", "to": "review-areas" },
+    { "from": "review-areas", "to": "choose-focus" },
+    { "from": "choose-focus", "to": "finalize-review" }
+  ]
+}

--- a/examples/second-brain/.agentic/workflows/yearly-review.json
+++ b/examples/second-brain/.agentic/workflows/yearly-review.json
@@ -1,0 +1,69 @@
+{
+  "id": "yearly-review",
+  "name": "Yearly review",
+  "description": "Synthesize the year, extract long-term lessons, and choose next-year direction.",
+  "version": "1.0",
+  "nodes": [
+    {
+      "id": "collect-year",
+      "label": "Collect year",
+      "description": "Gather monthly reviews, major artifacts, completed projects, and meaningful area changes.",
+      "artifact": {
+        "type": "year-review-inputs",
+        "description": "Collected source material for yearly review.",
+        "required": true,
+        "tags": ["second-brain", "review", "yearly"]
+      }
+    },
+    {
+      "id": "identify-themes",
+      "label": "Identify themes",
+      "description": "Find repeated patterns, compounding wins, recurring failures, and identity-level shifts.",
+      "artifact": {
+        "type": "yearly-themes",
+        "description": "Themes and lessons from the year.",
+        "required": true,
+        "tags": ["second-brain", "reflection", "yearly"]
+      }
+    },
+    {
+      "id": "archive-completed-work",
+      "label": "Archive completed work",
+      "description": "Identify projects to archive and resources or memories to preserve for long-term use.",
+      "artifact": {
+        "type": "archive-plan",
+        "description": "Project archive and preservation plan.",
+        "required": true,
+        "tags": ["second-brain", "archive", "resource"]
+      }
+    },
+    {
+      "id": "set-direction",
+      "label": "Set direction",
+      "description": "Choose next-year priorities, standards, and explicit non-goals.",
+      "artifact": {
+        "type": "yearly-plan",
+        "description": "Next-year direction and planning decisions.",
+        "required": true,
+        "tags": ["second-brain", "review", "plan"]
+      }
+    },
+    {
+      "id": "finalize-review",
+      "label": "Finalize review",
+      "description": "Finalize the yearly review artifact and create follow-up projects or area standards.",
+      "artifact": {
+        "type": "finalized-artifact-ref",
+        "description": "Reference to finalized yearly review and resulting project/task updates.",
+        "required": true,
+        "tags": ["second-brain", "artifact", "tasks"]
+      }
+    }
+  ],
+  "edges": [
+    { "from": "collect-year", "to": "identify-themes" },
+    { "from": "identify-themes", "to": "archive-completed-work" },
+    { "from": "archive-completed-work", "to": "set-direction" },
+    { "from": "set-direction", "to": "finalize-review" }
+  ]
+}

--- a/examples/second-brain/AGENTS.md
+++ b/examples/second-brain/AGENTS.md
@@ -1,0 +1,136 @@
+# AGENTS.md — Second-Brain Example
+
+Use this file as the harness bootstrap for agents working in this example workspace.
+
+## What This Is
+
+This directory is an Agentic second-brain research workspace. Agentic provides the durable primitives; the harness provides the model call, tools, research access, and execution loop.
+
+Workspace base dir:
+
+```bash
+examples/second-brain
+```
+
+## Start Here
+
+At the start of a research turn, activate the researcher persona:
+
+```bash
+agentic persona activate researcher --base-dir examples/second-brain
+```
+
+Treat the output as operating context for the turn. Follow the persona's instructions.
+
+Then gather the current working context:
+
+```bash
+agentic task next --base-dir examples/second-brain
+agentic skill run research-brief --base-dir examples/second-brain
+```
+
+If this workspace has a user-provided memory adapter or seeded user memories, recall relevant context as well. This public example does not ship with memory records.
+
+If the installed `agentic` binary is unavailable while working from this repo, use:
+
+```bash
+bun ../../packages/agentic/src/cli/main.ts persona activate researcher --base-dir .
+bun ../../packages/agentic/src/cli/main.ts task next --base-dir .
+bun ../../packages/agentic/src/cli/main.ts skill run research-brief --base-dir .
+```
+
+When running `project-kickoff`, load its skill before planning:
+
+```bash
+agentic skill run project-kickoff --base-dir examples/second-brain
+```
+
+## Running a Workflow
+
+The local runtime can create a workflow run and report next steps:
+
+```bash
+agentic runtime run research-loop --base-dir examples/second-brain
+```
+
+This creates a run, prints the run ID, and lists the first available nodes. Then drive transitions:
+
+```bash
+agentic workflow start <run-id> <node-id> --base-dir examples/second-brain
+agentic workflow done <run-id> <node-id> --artifact-type <type> --base-dir examples/second-brain
+agentic workflow next <run-id> --base-dir examples/second-brain
+```
+
+The runtime does not call the model or execute research. It creates the run structure and reports what is ready. The harness drives the transitions and calls Agentic primitives for artifact management at each step.
+
+Omit the target to list available workflows:
+
+```bash
+agentic runtime run --base-dir examples/second-brain
+```
+
+The local runtime must be initialized first (one-time setup):
+
+```bash
+agentic runtime add local --base-dir examples/second-brain
+agentic runtime init local --base-dir examples/second-brain
+```
+
+## How To Use Agentic
+
+- Use `persona activate` to load the hat and turn-level operating instructions.
+- Use `skill run` to load reusable procedures.
+- Use `memory recall` only when the user has configured memory records or an adapter for this workspace.
+- Use `task next` to find the active research question.
+- Use `runtime run <target>` to create a workflow run and discover next steps.
+- Use `workflow start/done/next` to drive transitions through a workflow run.
+- Use `artifact create`, `artifact write`, and `artifact finalize` for durable outputs.
+- Finalize artifacts only after the workflow's taxonomy validation step passes.
+- When a workflow step requires user intent that is not already available, ask concise questions before creating durable artifacts. Label any assumptions explicitly.
+
+## Boundary
+
+Agentic is not the harness. Do not expect it to browse, call a model, schedule work, manage auth, or execute approvals.
+
+The harness owns:
+
+- Model calls
+- Tool execution
+- Web or file research
+- Credentials and authorization
+- Scheduling and notifications
+- Final user communication
+
+Agentic owns:
+
+- Personas
+- Skills
+- Memories when the user configures them
+- Tasks
+- Workflows
+- Artifacts
+- Run creation and step discovery (via the local runtime)
+
+## Research Output
+
+When research produces a reusable answer, persist it as a `research-brief` artifact. Do not leave the final answer only in the transcript.
+
+Every artifact must include at least one PARA bucket tag:
+
+```text
+para:<bucket>/<slug>
+```
+
+Allowed buckets are `project`, `area`, `resource`, and `archive`. The slug names the concrete bucket, such as `para:project/visible-switch-research`, `para:area/personal-finance`, or `para:resource/cellular-plans`.
+
+For multi-step research, use the `research-loop` workflow as the enforcement gate: write the brief, validate taxonomy, then finalize the artifact. Finalization means the artifact is durable output for this research pass.
+
+Use this shape:
+
+- Question
+- Why It Matters
+- Findings
+- Tradeoffs
+- Recommendation
+- Sources Consulted
+- Follow-Up Questions

--- a/examples/second-brain/README.md
+++ b/examples/second-brain/README.md
@@ -1,0 +1,262 @@
+# Second-Brain Research Example
+
+This example shows Agentic as a small research operating system: personas, skills, workflows, a task queue, and finalized artifacts.
+
+It is intentionally personal-workflow shaped rather than product-demo shaped. The point is not to automate research end-to-end. The point is to give an agent enough durable structure to pick up a question, preserve useful findings, and produce a reusable brief without turning Agentic into a host runtime.
+
+## Big Picture
+
+Agentic is the primitive layer. It stores and loads the pieces an agent needs inside a turn, but it does not call the model or execute research by itself.
+
+In this example:
+
+- The harness reads `AGENTS.md` to learn how to enter the workspace.
+- The harness activates the `researcher` persona and gives that output to the model.
+- The agent uses `task next` and `skill run` to gather working context.
+- The agent uses the `research-loop` workflow to keep multi-step research resumable.
+- The agent writes the final answer as an artifact so the result survives beyond the transcript.
+
+The host harness still owns model calls, tool execution, browsing, credentials, approvals, scheduling, and user communication.
+
+## Try It
+
+From the repo root:
+
+```bash
+bun src/cli/main.ts persona activate researcher --base-dir examples/second-brain
+bun src/cli/main.ts skill run research-brief --base-dir examples/second-brain
+bun src/cli/main.ts workflow list --base-dir examples/second-brain
+bun src/cli/main.ts task next --base-dir examples/second-brain
+bun src/cli/main.ts artifact list --base-dir examples/second-brain
+```
+
+After installing the package, replace `bun src/cli/main.ts` with `agentic`.
+
+Agent harnesses should start with [`AGENTS.md`](AGENTS.md). It contains the minimal bootstrap instructions for when and how to call Agentic primitives inside this workspace.
+
+## Running Locally
+
+The second-brain example can run end-to-end through the local runtime, no Cloudflare or external service required.
+
+### Setup
+
+From the repo root, install dependencies and initialize the local runtime:
+
+```bash
+bun install
+cd examples/second-brain
+agentic runtime add local
+agentic runtime init local
+```
+
+This creates `.agentic/runtime/local/runtime.json` and a `targets/` directory. The local runtime is now configured as the default in `.agentic/config.toml`.
+
+### Run a workflow
+
+```bash
+cd examples/second-brain
+agentic runtime run research-loop
+```
+
+This creates a workflow run, prints the run ID, and lists the first available nodes. Drive transitions with:
+
+```bash
+agentic workflow start <run-id> <node-id>
+agentic workflow done <run-id> <node-id> --artifact-type <type>
+agentic workflow next <run-id>
+```
+
+Omit the target to list available workflows:
+
+```bash
+agentic runtime run
+```
+
+### What happens
+
+1. `runtime run` resolves the target to a workflow graph defined in `.agentic/workflows/`.
+2. It creates a run record in `.agentic/runs/` (gitignored by default).
+3. It returns the run ID and the first available node(s).
+4. The harness drives transitions: `start` marks a node in-progress, `done` marks it complete and optionally attaches an artifact type, `next` returns the next available node(s).
+5. The harness creates artifacts (research briefs, project plans, etc.) using `artifact create` and `artifact finalize`.
+6. When all required nodes are complete, the workflow run is finished.
+
+### What Agentic owns vs. the local runtime
+
+| Concern | Agentic core | Local runtime |
+|---|---|---|
+| Persona, skill, workflow definitions | Owns | Uses |
+| Task and artifact storage | Owns | Uses |
+| Workflow state and transitions | Owns | Uses |
+| Creating a run from a target | Delegates | Owns |
+| Running a harness or model call | — | Does not own (the harness does) |
+
+The local runtime creates runs and reports available next steps. It does not call the model, execute research, or drive transitions on its own. The harness (you, an agent, or a script) decides when to start and complete each node.
+
+### What is not here yet
+
+- **Daemon/service mode:** The local runtime does not watch for tasks or run on a schedule. You drive it manually or from a harness script.
+- **Cloudflare deployment:** The `local` target is the only implemented runtime. A Cloudflare Workers runtime is a future target, not a current one.
+- **External artifact storage:** Artifacts live in `.agentic/artifacts/` on the filesystem. Cross-environment sync is tracked in [#99](https://github.com/tnezdev/agentic/issues/99).
+- **Session primitive:** There is no session abstraction yet. Runs are the unit of continuity.
+
+## How The Pieces Work Together
+
+### Harness Bootstrap
+
+`AGENTS.md` is not an Agentic primitive. It is a harness convention: a short file that tells an agent how to use this workspace.
+
+It answers the questions a generic harness needs at startup:
+
+- Which base directory should Agentic commands use?
+- Which persona should activate first?
+- Which task and skill should be loaded?
+- What is Agentic responsible for, and what does the harness still own?
+- What must be true before an artifact is finalized?
+
+### Persona
+
+`.agentic/personas/researcher.md` is the agent's operating mode for this workspace.
+
+It declares:
+
+- `memory_tags`: which memories are relevant to recall.
+- `skills`: which procedures are likely useful.
+- `task_filter`: which tasks belong to this hat.
+- `workflow`: the default workflow for this kind of work.
+- Body text: the actual instructions rendered into context at activation time.
+
+Running `persona activate researcher` prints the rendered persona. A harness should treat that output as prompt/context for the turn.
+
+### Skill
+
+`.agentic/skills/research-brief/skill.md` is the reusable procedure for producing a research brief.
+
+It tells the agent how to move from open question to durable answer, including the expected artifact sections and the requirement to validate PARA taxonomy before finalization.
+
+Skills are loaded on demand. They keep repeated procedures out of a bloated always-on system prompt.
+
+### Memory
+
+Agentic supports memory, but this public example does not ship with `.agentic/memory/*.json` records.
+
+That is intentional. Memory is user-space: users may bring their own memories, storage adapters, and retention rules. A harness using this workspace can still call `memory recall` when user memory is configured, but the example itself keeps durable example output in artifacts.
+
+Memories are not a transcript. They are compact facts the user wants the agent to remember across sessions.
+
+### Task
+
+`.agentic/tasks/*.json` stores open work.
+
+The seeded task gives the agent a concrete research question to pick up. In a real second-brain workspace, tasks would be the research questions, decisions, or follow-ups that should not disappear between turns.
+
+### Workflow
+
+`.agentic/workflows/*.json` contains stateful processes for repeated second-brain operations.
+
+The research workflow is:
+
+```text
+frame-question
+→ gather-sources
+→ write-brief
+→ validate-taxonomy
+→ finalize-brief
+→ decide-next-actions
+```
+
+The important part is the review gate:
+
+- `write-brief` creates or updates the draft research artifact.
+- `validate-taxonomy` confirms the artifact has a valid PARA bucket tag.
+- `finalize-brief` finalizes the artifact only after validation passes.
+
+This is intentionally workflow-enforced rather than globally enforced by Agentic. Second-brain taxonomy rules are user- and workspace-specific, so the example encodes them in the workflow, skill, and harness instructions.
+
+This example also includes other common second-brain workflows:
+
+| Workflow | Use it when |
+|---|---|
+| `research-loop` | Turning an open question into a durable research brief |
+| `project-kickoff` | Turning an idea into a scoped PARA project with next actions; starts with user intake questions |
+| `project-archive` | Closing a project, preserving lessons, and reclassifying useful material |
+| `weekly-review` | Reviewing active commitments and choosing next-week focus |
+| `monthly-review` | Reviewing the project/area/resource portfolio and choosing next-month focus |
+| `yearly-review` | Synthesizing the year and choosing next-year direction |
+| `process-inbox` | Routing uncategorized captures into tasks, memories, artifacts, or PARA buckets |
+
+### Artifact
+
+`.agentic/artifacts/*` stores durable outputs.
+
+The seed artifact is a finalized `research-brief`. It demonstrates the expected output shape and the required PARA tag convention:
+
+```text
+para:<bucket>/<slug>
+```
+
+Allowed buckets are:
+
+- `project`
+- `area`
+- `resource`
+- `archive`
+
+Example tags:
+
+- `para:project/visible-switch-research`
+- `para:area/personal-finance`
+- `para:resource/cellular-plans`
+- `para:archive/old-research`
+
+Finalization means the artifact is durable output for this research pass. It does not mean the answer can never be superseded.
+
+## What Is In Here
+
+| Path | Primitive | Purpose |
+|---|---|---|
+| `AGENTS.md` | Harness bootstrap | Minimal instructions for agents using this workspace |
+| `.agentic/personas/researcher.md` | Persona | Activates the research hat: question-first, source-aware, concise synthesis |
+| `.agentic/skills/research-brief/skill.md` | Skill | Agent-facing procedure for turning a question into a cited brief |
+| `.agentic/skills/project-kickoff/skill.md` | Skill | Agent-facing procedure for interviewing before drafting a project plan |
+| `.agentic/workflows/*.json` | Workflow | Research, project, review, archive, and inbox operating loops |
+| `.agentic/tasks/*.json` | Tasks | A real ready task seeded with an example research question |
+| `.agentic/artifacts/*` | Artifact | A finalized sample brief showing the target output |
+| `.agentic/runtime/local/` | Runtime config | Local runtime glue (created by `runtime init local`) |
+
+## Dogfooding Loop
+
+To dogfood this example, use it for one real research question and watch for friction.
+
+1. Activate the persona.
+2. Load the task and skill.
+3. Start or inspect a `research-loop` workflow run.
+4. Do the research using whatever tools the harness provides.
+5. Create or update a `research-brief` artifact.
+6. Validate that the artifact has a `para:<bucket>/<slug>` tag.
+7. Finalize the artifact.
+8. Mark the task done or add follow-up tasks.
+
+Good dogfood findings are not just better answers. They are also places where the primitive boundaries feel wrong, missing, or too ceremonial.
+
+## Why This Shape
+
+Second-brain work repeats. The questions change, but the operating shape stays stable:
+
+- Activate a persona so the agent knows how to think.
+- Run a skill so the work procedure is explicit and reusable.
+- Advance a workflow so multi-step work has state.
+- Track tasks so open loops do not disappear.
+- Write artifacts so the output becomes durable and inspectable.
+
+Agentic owns those primitives. The local runtime owns run creation and step discovery. Your host harness still owns model calls, tool execution, browsing, credentials, scheduling, approvals, and notification surfaces.
+
+## Extending It
+
+Use this as a starter shape, not a template to preserve exactly.
+
+- Add memories for your own source standards, output preferences, and active research areas.
+- Add skills for recurring research genres: literature review, product comparison, meeting prep, or decision memo.
+- Add workflow nodes only when they represent real state you need to resume later.
+- Keep artifacts as the durable outputs; do not rely on a transcript as the source of truth.
+- Add runtime targets only when you need different execution environments. The public target is `local`; future targets (Cloudflare Workers, etc.) are not yet implemented.

--- a/examples/second-brain/package.json
+++ b/examples/second-brain/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "second-brain-example",
+  "private": true,
+  "devDependencies": {
+    "@tnezdev/agentic-runtime-local": "workspace:*"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "type": "module",
   "workspaces": [
-    "packages/*"
+    "packages/*",
+    "examples/*"
   ],
   "scripts": {
     "build": "bun run --cwd packages/agentic build && bun run --cwd packages/agentic-runtime-local build",

--- a/packages/agentic-runtime-local/src/index.test.ts
+++ b/packages/agentic-runtime-local/src/index.test.ts
@@ -1,9 +1,57 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test"
-import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { mkdtemp, readFile, rm, mkdir, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 import type { RuntimeContext } from "@tnezdev/agentic/runtime"
 import { runtime } from "./index.js"
+import type { GraphDef, Run, Transition, WorkflowAdapter } from "@tnezdev/agentic"
+
+/** Minimal workflow adapter for testing run without filesystem. */
+class InMemoryWorkflowAdapter implements WorkflowAdapter {
+  private graphs: Map<string, GraphDef> = new Map()
+  private runs: Map<string, Run> = new Map()
+  private runCounter = 0
+
+  async saveGraph(graph: GraphDef): Promise<void> { this.graphs.set(graph.id, graph) }
+  async loadGraph(graphId: string, _version?: string): Promise<GraphDef | undefined> { return this.graphs.get(graphId) }
+  async listGraphs(): Promise<GraphDef[]> { return [...this.graphs.values()] }
+  async saveSourceGraph?(graph: GraphDef): Promise<void> { this.graphs.set(graph.id, graph) }
+  async loadSourceGraph?(graphId: string): Promise<GraphDef | undefined> { return this.graphs.get(graphId) }
+
+  async createRun(graphId: string, name?: string, graphVersion?: string): Promise<Run> {
+    this.runCounter++
+    const run: Run = {
+      run_id: `run-${this.runCounter}`,
+      graph_id: graphId,
+      ...((graphVersion !== undefined) && { graph_version: graphVersion }),
+      ...((name !== undefined) && { name }),
+      history: [],
+      created_at: new Date().toISOString(),
+    }
+    this.runs.set(run.run_id, run)
+    return run
+  }
+  async loadRun(runId: string): Promise<Run | undefined> { return this.runs.get(runId) }
+  async listRuns(_graphId?: string): Promise<Run[]> { return [...this.runs.values()] }
+  async appendTransition(runId: string, transition: Transition): Promise<void> {
+    const run = this.runs.get(runId)
+    if (run) run.history.push(transition)
+  }
+}
+
+const sampleGraph: GraphDef = {
+  id: "project-kickoff",
+  name: "Project kickoff",
+  description: "Turn a project idea into a scoped PARA project",
+  version: "1",
+  nodes: [
+    { id: "intake", label: "Ask kickoff questions", artifact: { type: "project-intake", required: true } },
+    { id: "plan", label: "Create project plan", artifact: { type: "project-plan", required: true } },
+  ],
+  edges: [
+    { from: "intake", to: "plan" },
+  ],
+}
 
 describe("local runtime package", () => {
   let tmpDir: string
@@ -20,19 +68,10 @@ describe("local runtime package", () => {
       env: {},
       config: {
         adapter: "filesystem",
-        memory: {
-          dir: ".agentic/memory",
-          defaultTier: "L1",
-          dreamDepth: 3,
-        },
-        workflow: {
-          graphsDir: ".agentic/workflows",
-          runsDir: ".agentic/runs",
-        },
+        memory: { dir: ".agentic/memory", defaultTier: "L1", dreamDepth: 3 },
+        workflow: { graphsDir: ".agentic/workflows", runsDir: ".agentic/runs" },
         wake: {},
-        runtime: {
-          targets: {},
-        },
+        runtime: { targets: {} },
       },
       runtime_config: {},
       agentic: {} as RuntimeContext["agentic"],
@@ -86,18 +125,90 @@ describe("local runtime package", () => {
     })
   })
 
-  it("returns a placeholder run result", async () => {
+  it("requires initialization before run", async () => {
     const result = await runtime.commands.run!(ctx, {
-      target: "examples/second-brain",
-      args: ["--dry-run"],
+      target: "project-kickoff",
+      args: [],
       flags: {},
     })
 
-    expect(result?.summary).toContain("not implemented yet")
+    expect(result?.summary).toContain("not initialized")
+    expect(result?.data).toMatchObject({ target: "project-kickoff", initialized: false })
+  })
+
+  it("lists available workflows when no target specified", async () => {
+    await runtime.commands.init!(ctx, { args: [], flags: {} })
+
+    // Set up workflow adapter with a sample graph
+    const adapter = new InMemoryWorkflowAdapter()
+    await adapter.saveGraph(sampleGraph)
+    ctx.agentic = { ...ctx.agentic, workflows: adapter }
+
+    const result = await runtime.commands.run!(ctx, { target: undefined, args: [], flags: {} })
+
+    expect(result?.summary).toContain("Specify a target workflow")
+    expect(result?.summary).toContain("project-kickoff")
     expect(result?.data).toMatchObject({
-      target: "examples/second-brain",
-      args: ["--dry-run"],
-      initialized: false,
+      initialized: true,
+      available_graphs: [{ id: "project-kickoff", name: "Project kickoff" }],
+    })
+  })
+
+  it("reports empty workflows when none exist", async () => {
+    await runtime.commands.init!(ctx, { args: [], flags: {} })
+
+    const adapter = new InMemoryWorkflowAdapter()
+    ctx.agentic = { ...ctx.agentic, workflows: adapter }
+
+    const result = await runtime.commands.run!(ctx, { target: undefined, args: [], flags: {} })
+
+    expect(result?.summary).toContain("No workflows found")
+  })
+
+  it("creates a run when target resolves to a workflow", async () => {
+    await runtime.commands.init!(ctx, { args: [], flags: {} })
+
+    const adapter = new InMemoryWorkflowAdapter()
+    await adapter.saveGraph(sampleGraph)
+    ctx.agentic = { ...ctx.agentic, workflows: adapter }
+
+    const result = await runtime.commands.run!(ctx, {
+      target: "project-kickoff",
+      args: [],
+      flags: {},
+    })
+
+    expect(result?.summary).toContain("Created run")
+    expect(result?.summary).toContain("Project kickoff")
+    expect(result?.summary).toContain("run-1")
+    expect(result?.data).toMatchObject({
+      target: "project-kickoff",
+      initialized: true,
+      graph_id: "project-kickoff",
+      graph_name: "Project kickoff",
+    })
+    const data = result?.data as Record<string, unknown>
+    expect(data.run_id).toBeString()
+    expect(data.available_nodes).toBeArray()
+  })
+
+  it("reports not found for unknown target", async () => {
+    await runtime.commands.init!(ctx, { args: [], flags: {} })
+
+    const adapter = new InMemoryWorkflowAdapter()
+    await adapter.saveGraph(sampleGraph)
+    ctx.agentic = { ...ctx.agentic, workflows: adapter }
+
+    const result = await runtime.commands.run!(ctx, {
+      target: "nonexistent-workflow",
+      args: [],
+      flags: {},
+    })
+
+    expect(result?.summary).toContain("not found")
+    expect(result?.data).toMatchObject({
+      target: "nonexistent-workflow",
+      error: "graph_not_found",
     })
   })
 })

--- a/packages/agentic-runtime-local/src/index.ts
+++ b/packages/agentic-runtime-local/src/index.ts
@@ -1,5 +1,6 @@
 import { access, mkdir, readFile, stat, writeFile } from "node:fs/promises"
 import { join, relative } from "node:path"
+import { Runtime } from "@tnezdev/agentic"
 import type {
   AgenticRuntimePackage,
   RuntimeCommandResult,
@@ -8,6 +9,7 @@ import type {
   RuntimeRunArgs,
   RuntimeStatusArgs,
 } from "@tnezdev/agentic/runtime"
+import type { GraphDef } from "@tnezdev/agentic"
 
 const RUNTIME_NAME = "local"
 const PACKAGE_NAME = "@tnezdev/agentic-runtime-local"
@@ -103,12 +105,76 @@ async function runLocalRuntime(
   ctx: RuntimeContext,
   args: RuntimeRunArgs,
 ): Promise<RuntimeCommandResult> {
+  const initialized = await pathExists(statePath(ctx))
+  if (!initialized) {
+    return {
+      summary: "Local runtime is not initialized. Run `agentic runtime init local` first.",
+      data: {
+        target: args.target ?? null,
+        initialized: false,
+      },
+    }
+  }
+
+  const target = args.target
+  if (!target) {
+    const graphs = await ctx.agentic.workflows.listGraphs()
+    const graphList = graphs.map((g: GraphDef) => `  ${g.id} — ${g.name}`).join("\n")
+    return {
+      summary: graphs.length > 0
+        ? `Specify a target workflow to run. Available workflows:\n${graphList}`
+        : "No workflows found in this workspace. Add workflows to .agentic/workflows/ first.",
+      data: {
+        target: null,
+        initialized: true,
+        available_graphs: graphs.map((g: GraphDef) => ({ id: g.id, name: g.name })),
+      },
+    }
+  }
+
+  // Resolve target to a workflow graph
+  const graph = await ctx.agentic.workflows.loadGraph(target)
+  if (!graph) {
+    const graphs = await ctx.agentic.workflows.listGraphs()
+    const graphList = graphs.map((g: GraphDef) => `  ${g.id} — ${g.name}`).join("\n")
+    return {
+      summary: `Workflow "${target}" not found. Available workflows:\n${graphList || "  (none)"}`,
+      data: {
+        target,
+        initialized: true,
+        error: "graph_not_found",
+        available_graphs: graphs.map((g: GraphDef) => ({ id: g.id, name: g.name })),
+      },
+    }
+  }
+
+  // Create a workflow run
+  const rt = new Runtime(ctx.agentic.workflows)
+  const run = await rt.createRun(graph.id)
+  const available = await rt.next(graph.id, run.run_id)
+
+  // Build node info for available first steps
+  const nodeInfo = available.map((nodeId: string) => {
+    const node = graph.nodes.find((n) => n.id === nodeId)
+    return {
+      id: nodeId,
+      label: node?.label ?? nodeId,
+      type: node?.type ?? "automated",
+      artifact_type: node?.artifact?.type ?? node?.artifact_type ?? null,
+    }
+  })
+
+  const label = graph.name ?? graph.id
+
   return {
-    summary: "Local runtime execution is not implemented yet.",
+    summary: `Created run for "${label}" (${graph.id}).\n\nRun ID: ${run.run_id}\n\nNext steps (ready to start):\n${nodeInfo.map((n: { id: string; label: string; artifact_type: string | null }) => `  ${n.id}: ${n.label}${n.artifact_type ? ` → ${n.artifact_type}` : ""}`).join("\n")}\n\nDrive transitions with:\n  agentic workflow start ${run.run_id} <node-id>\n  agentic workflow done ${run.run_id} <node-id> --artifact-type <type>\n  agentic workflow next ${run.run_id}`,
     data: {
-      target: args.target ?? null,
-      args: args.args,
-      initialized: await pathExists(statePath(ctx)),
+      target,
+      initialized: true,
+      run_id: run.run_id,
+      graph_id: graph.id,
+      graph_name: graph.name,
+      available_nodes: nodeInfo,
     },
   }
 }

--- a/packages/agentic/src/cli/main.ts
+++ b/packages/agentic/src/cli/main.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env bun
 
+import { resolve } from "node:path"
 import { loadConfig } from "../config.js"
 import { FilesystemAdapter } from "../memory/filesystem.js"
 import type { Ctx, Command } from "./context.js"
@@ -230,7 +231,7 @@ async function main() {
   }
 
   const baseDir =
-    typeof flags["base-dir"] === "string" ? flags["base-dir"] : process.cwd()
+    typeof flags["base-dir"] === "string" ? resolve(flags["base-dir"]) : process.cwd()
   const json = flags["json"] === true
   const wide = flags["wide"] === true
   const config = await loadConfig(baseDir)

--- a/packages/agentic/src/workflow/filesystem.ts
+++ b/packages/agentic/src/workflow/filesystem.ts
@@ -74,16 +74,22 @@ export class FilesystemWorkflowAdapter implements WorkflowAdapter {
   }
 
   async loadGraph(graphId: string, version?: string): Promise<GraphDef | undefined> {
-    const name =
-      version === undefined ? graphId : versionedGraphName(graphId, version)
-    for (const ext of [".json", ".yaml", ".yml"]) {
-      const filePath = join(this.graphsDir, `${name}${ext}`)
-      try {
-        const data = await readFile(filePath, "utf-8")
-        return parseGraph(data, filePath)
-      } catch (err) {
-        if (isNodeError(err) && err.code === "ENOENT") continue
-        throw err
+    // Try versioned name first, then fall back to unversioned.
+    // Source graphs (hand-written workflow files) only have the unversioned copy;
+    // compiled/expanded graphs saved by saveGraph have both.
+    const names = version === undefined
+      ? [graphId]
+      : [versionedGraphName(graphId, version), graphId]
+    for (const name of names) {
+      for (const ext of [".json", ".yaml", ".yml"]) {
+        const filePath = join(this.graphsDir, `${name}${ext}`)
+        try {
+          const data = await readFile(filePath, "utf-8")
+          return parseGraph(data, filePath)
+        } catch (err) {
+          if (isNodeError(err) && err.code === "ENOENT") continue
+          throw err
+        }
       }
     }
     return undefined


### PR DESCRIPTION
Closes #112

## What

Updates the second-brain example so a new user can understand and run it through the local runtime — without Cloudflare, daemon mode, or external services.

## Changes

### Example docs (README.md)

- Added **Running Locally** section with setup, `runtime run`, and workflow transition commands
- Added **What happens** walkthrough explaining the run lifecycle
- Added **What Agentic owns vs. the local runtime** comparison table
- Added **What is not here yet** section covering daemon, Cloudflare, sessions, and external artifact storage
- Updated **What Is In Here** table to include `.agentic/runtime/local/`
- Updated **Why This Shape** to reflect runtime ownership
- Updated **Extending It** with runtime target guidance

### Harness docs (AGENTS.md)

- Added **Running a Workflow** section with `runtime run`, `workflow start/done/next` commands
- Added `runtime run` and `workflow start/done/next` to the Agentic usage list
- Updated Boundary section to include run creation and step discovery

### Seed data

- Added `.agentic/tasks/01KTC500000000000000000001.json` — seed research task
- Added `.agentic/artifacts/01KTC500000000000000000010/` — seed research brief (finalized)

### Code changes (prior dogfood session, now committed)

- `runtime run <target>` creates a workflow run and returns available next nodes
- `runtime run` (no target) lists available workflows
- CLI resolves `--base-dir` to absolute path for consistent path handling
- Workflow filesystem adapter falls back from versioned to unversioned graph names
- Root `package.json` includes `examples/*` in workspaces
- Root `.agentic/config.toml` adds runtime config for local dogfood

## Acceptance criteria

- ✅ Example README includes a runnable local-runtime path
- ✅ Docs distinguish Agentic core from the local runtime clearly
- ✅ Docs connect back to #100 without duplicating its roadmap
- ✅ A future user can answer "how do I actually run this thing?" from the example docs alone

## Testing

- All 642 existing tests pass
- Manual end-to-end: `runtime run research-loop` creates a run, returns node info, and workflow transitions work